### PR TITLE
Resolve directory dependencies with index.js

### DIFF
--- a/src/project.js
+++ b/src/project.js
@@ -144,12 +144,21 @@ function isInternalCommonJSDependency (dependency) {
 
 function isDependency (from, dependency, to) {
     var dependencyPath = dependency.path;
+    var fromFileAbsolutePath = path.resolve(from)
+    var toFileAbsolutePath = path.resolve(to)
+    var dependencyAbsolutePath = path.resolve(path.dirname(fromFileAbsolutePath), dependencyPath)
 
     if (path.extname(dependencyPath) === '') {
-        dependencyPath += path.extname(to);
+        var index = path.join(dependencyAbsolutePath, 'index.js')
+
+        if (index === toFileAbsolutePath) {
+            return true
+        } else {
+            dependencyAbsolutePath += path.extname(to);
+        }
     }
 
-    return path.resolve(path.dirname(from), dependencyPath) === to;
+    return dependencyAbsolutePath === toFileAbsolutePath
 }
 
 function percentifyDensity (density, matrix) {

--- a/test/project.js
+++ b/test/project.js
@@ -322,6 +322,62 @@ suite('project:', function () {
 
         });
 
+        suite('require directory (index.js)', function () {
+          setup(function () {
+              this.path1 = '/b.js';
+              this.path2 = '/mod/index.js';
+              this.path3 = '/mod/a.js';
+
+              var result = cr.analyse([
+                  { ast: esprima.parse('require("./mod")',   { loc: true }), path: this.path1 },
+                  { ast: esprima.parse('require("./a")',     { loc: true }), path: this.path2 },
+                  { ast: esprima.parse('require("../b.js")', { loc: true }), path: this.path3 }
+              ], mozWalker);
+
+              this.processResults = cr.processResults(result);
+          });
+
+          test('adjacency matrix is correct', function () {
+              assert.strictEqual(this.processResults.reports[0].path, this.path1);
+              assert.strictEqual(this.processResults.reports[1].path, this.path3);
+              assert.strictEqual(this.processResults.reports[2].path, this.path2);
+
+              assert.strictEqual(this.processResults.adjacencyMatrix.length, 3);
+
+              assert.strictEqual(this.processResults.adjacencyMatrix[0][0], 0);
+              assert.strictEqual(this.processResults.adjacencyMatrix[0][1], 0);
+              assert.strictEqual(this.processResults.adjacencyMatrix[0][2], 1);
+
+              assert.strictEqual(this.processResults.adjacencyMatrix[1][0], 1);
+              assert.strictEqual(this.processResults.adjacencyMatrix[1][1], 0);
+              assert.strictEqual(this.processResults.adjacencyMatrix[1][2], 0);
+
+              assert.strictEqual(this.processResults.adjacencyMatrix[2][0], 0);
+              assert.strictEqual(this.processResults.adjacencyMatrix[2][1], 1);
+              assert.strictEqual(this.processResults.adjacencyMatrix[2][2], 0);
+          });
+
+          test('visibility matrix is correct', function () {
+              assert.strictEqual(this.processResults.reports[0].path, this.path1);
+              assert.strictEqual(this.processResults.reports[1].path, this.path3);
+              assert.strictEqual(this.processResults.reports[2].path, this.path2);
+
+              assert.strictEqual(this.processResults.visibilityMatrix.length, 3);
+
+              assert.strictEqual(this.processResults.visibilityMatrix[0][0], 0);
+              assert.strictEqual(this.processResults.visibilityMatrix[0][1], 1);
+              assert.strictEqual(this.processResults.visibilityMatrix[0][2], 1);
+
+              assert.strictEqual(this.processResults.visibilityMatrix[1][0], 1);
+              assert.strictEqual(this.processResults.visibilityMatrix[1][1], 0);
+              assert.strictEqual(this.processResults.visibilityMatrix[1][2], 1);
+
+              assert.strictEqual(this.processResults.visibilityMatrix[2][0], 1);
+              assert.strictEqual(this.processResults.visibilityMatrix[2][1], 1);
+              assert.strictEqual(this.processResults.visibilityMatrix[2][2], 0);
+          });
+        });
+
         suite('modules with dependencies:', function () {
             var result;
 


### PR DESCRIPTION
Currently when calculating the adjacency/visibility matrices, the require calls in the following form `require('./something')` are translated into `require('./something.js')`.

That's fine if the script was really there, but we're missing the case where `something` is a directory and the intention was to `require('./something/index.js')`, which is very common.