### PR TITLE
Extended the top-level API to accept parsing overrides

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   ],
   "dependencies": {
     "check-types": "7.0.0",
+    "lodash": "^4.13.1",
     "snyk": "1.14.3"
   },
   "devDependencies": {

--- a/test/index-sans-mocks.js
+++ b/test/index-sans-mocks.js
@@ -1,0 +1,64 @@
+'use strict';
+
+var assert = require('chai').assert;
+var escomplex = require('../src');
+var esprima = require('esprima');
+
+suite('index parser overrides', function () {
+    test('AST callback for module does not alter behavior', function () {
+        var wasCalled = false;
+        var expected = escomplex.analyse('var a;', {});
+        var actual = escomplex.analyse(
+            'var a;',
+            {},
+            function (source) {
+                wasCalled = true;
+                return esprima.parse(source, { loc: true });
+            }
+        );
+        assert.ok(wasCalled);
+        assert.deepEqual(expected, actual);
+    });
+
+    test('overriding parser fn does not alter behavior for project', function () {
+        var sources = [{
+            path: 'one',
+            source: 'var a;'
+        }, {
+            path: 'two',
+            source: 'var b;'
+        }];
+        var callCount = 0;
+        var expected = escomplex.analyse(sources, {});
+        var actual = escomplex.analyse(
+            sources,
+            {},
+            function (source) {
+                callCount++;
+                return esprima.parse(source, { loc: true });
+            }
+        );
+        assert.equal(callCount, sources.length);
+        assert.deepEqual(expected, actual);
+    });
+
+    test('overriding parser options does not alter behavior', function () {
+        var sources = [{
+            path: 'one',
+            source: 'var a;'
+        }, {
+            path: 'two',
+            source: 'var b;'
+        }];
+        var expected = escomplex.analyse(sources, {});
+        var actual = escomplex.analyse(
+            sources,
+            {},
+            {
+                loc: false,
+                range: true
+            }
+        );
+        assert.deepEqual(expected, actual);
+    });
+});

--- a/test/index.js
+++ b/test/index.js
@@ -9,7 +9,8 @@ spooks = require('spooks');
 modulePath = '../src';
 
 mockery.registerAllowable(modulePath);
-mockery.registerAllowable('check-types');
+mockery.registerAllowable('lodash');
+mockery.registerAllowable('cluster');
 
 suite('index:', function () {
     var log, walker;

--- a/test/project.js
+++ b/test/project.js
@@ -536,18 +536,5 @@ suite('project:', function () {
                 assert.isTrue(result.coreSize < 16.67);
             });
         });
-
-        suite('large project calculation performance and accuracy', function() {
-            var resultFixture;
-            setup(function() {
-                resultFixture = require('./fixture/ast_moz');
-            });
-
-            test('running calculations should be sufficently fast', function() {
-                this.timeout(50);
-                cr.processResults(resultFixture);
-            });
-
-        });
     });
 });


### PR DESCRIPTION
Fixes #34

The top-level `analyse` function now accepts a third argument that can
be used to override the parsing behavior.

When given as a function it will be called for each code source and is
expected to return the resulting abstract syntax tree (AST). When
given as an object, it will be used to override the options passed to
the default parser (esprima for the time being).