### PR TITLE
Updated unit tests to run across multiple parsers. Fixes #36.

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,19 +44,21 @@
     "check-types": "7.0.0",
     "debug": "^2.2.0",
     "espree": "^3.1.5",
-    "lodash": "^4.13.1",
-    "snyk": "1.14.3"
+    "lodash": "^4.13.1"
   },
   "devDependencies": {
+    "acorn": "^3.2.0",
     "chai": "3.5.0",
     "coveralls": "^2.11.9",
     "eslint": "2.13.1",
+    "esprima": "^2.7.2",
     "mocha": "2.5.3",
     "mocha-lcov-reporter": "^1.2.0",
     "mockery": "1.7.0",
     "nyc": "^6.6.1",
     "sinon": "1.17.4",
-    "spooks": "2.0.0"
+    "spooks": "2.0.0",
+    "snyk": "1.15.0"
   },
   "scripts": {
     "lint": "eslint test src",

--- a/src/module.js
+++ b/src/module.js
@@ -81,6 +81,7 @@ function getDefaultSettings () {
 }
 
 function createReport (lines) {
+    debug('aggregate report: ' + JSON.stringify(createFunctionReport(undefined, lines, 0), null, 2));
     return {
         aggregate: createFunctionReport(undefined, lines, 0),
         functions: [],
@@ -101,9 +102,11 @@ function createFunctionReport (name, lines, params) {
 
     if (check.object(lines)) {
         debug('Calculating line information...');
-        debug(JSON.stringify(lines));
+        debug('start line: ' + lines.start.line);
+        debug('end line: ' + lines.end.line);
         result.line = lines.start.line;
         result.sloc.physical = lines.end.line - lines.start.line + 1;
+        debug('physical lines: ' + result.sloc.physical);
     }
 
     return result;

--- a/test/helpers/parsers.js
+++ b/test/helpers/parsers.js
@@ -1,0 +1,27 @@
+'use strict';
+
+var parsers = [{
+    name: 'acorn',
+    parser: require('acorn'),
+    options: { locations: true, onComment: [] }
+},{
+    name: 'espree',
+    parser: require('espree'),
+    options: { loc: true, ecmaVersion: 6 }
+},{
+    name: 'esprima',
+    parser: require('esprima'),
+    options: { loc: true }
+}];
+
+module.exports.forEach = function forEachParser (tests) {
+    for(var i = 0; i < parsers.length; i++) {
+        var parserName = parsers[i].name;
+        var parser = parsers[i].parser;
+        var options = parsers[i].options;
+        suite('using the ' + parserName + ' parser:', function () {
+            tests(parserName, parser, options);
+        });
+    }
+}
+

--- a/test/index-sans-mocks.js
+++ b/test/index-sans-mocks.js
@@ -2,63 +2,65 @@
 
 var assert = require('chai').assert;
 var escomplex = require('../src');
-var espree = require('espree');
+var parsers = require('./helpers/parsers');
 
 suite('index parser overrides', function () {
-    test('AST callback for module does not alter behavior', function () {
-        var wasCalled = false;
-        var expected = escomplex.analyse('var a;', {});
-        var actual = escomplex.analyse(
-            'var a;',
-            {},
-            function (source) {
-                wasCalled = true;
-                return espree.parse(source, { loc: true });
-            }
-        );
-        assert.ok(wasCalled);
-        assert.deepEqual(expected, actual);
-    });
+    parsers.forEach(function (parserName, parser, options) {
+        test('AST callback for module does not alter behavior', function () {
+            var wasCalled = false;
+            var expected = escomplex.analyse('var a;', {});
+            var actual = escomplex.analyse(
+                'var a;',
+                {},
+                function (source) {
+                    wasCalled = true;
+                    return parser.parse(source, options);
+                }
+            );
+            assert.ok(wasCalled);
+            assert.deepEqual(expected, actual);
+        });
 
-    test('overriding parser fn does not alter behavior for project', function () {
-        var sources = [{
-            path: 'one',
-            source: 'var a;'
-        }, {
-            path: 'two',
-            source: 'var b;'
-        }];
-        var callCount = 0;
-        var expected = escomplex.analyse(sources, {});
-        var actual = escomplex.analyse(
-            sources,
-            {},
-            function (source) {
-                callCount++;
-                return espree.parse(source, { loc: true });
-            }
-        );
-        assert.equal(callCount, sources.length);
-        assert.deepEqual(expected, actual);
-    });
+        test('overriding parser fn does not alter behavior for project', function () {
+            var sources = [{
+                path: 'one',
+                source: 'var a;'
+            }, {
+                path: 'two',
+                source: 'var b;'
+            }];
+            var callCount = 0;
+            var expected = escomplex.analyse(sources, {});
+            var actual = escomplex.analyse(
+                sources,
+                {},
+                function (source) {
+                    callCount++;
+                    return parser.parse(source, options);
+                }
+            );
+            assert.equal(callCount, sources.length);
+            assert.deepEqual(expected, actual);
+        });
 
-    test('overriding parser options does not alter behavior', function () {
-        var sources = [{
-            path: 'one',
-            source: 'var a;'
-        }, {
-            path: 'two',
-            source: 'var b;'
-        }];
-        var expected = escomplex.analyse(sources, {});
-        var actual = escomplex.analyse(
-            sources,
-            {},
-            {
-                loc: false,
-                range: true
-            }
-        );
-        assert.deepEqual(expected, actual);
+        test('overriding parser options does not alter behavior', function () {
+            var sources = [{
+                path: 'one',
+                source: 'var a;'
+            }, {
+                path: 'two',
+                source: 'var b;'
+            }];
+            var expected = escomplex.analyse(sources, {});
+            var actual = escomplex.analyse(
+                sources,
+                {},
+                {
+                    loc: false,
+                    range: true
+                }
+            );
+            assert.deepEqual(expected, actual);
+        });
     });
 });

--- a/test/module.js
+++ b/test/module.js
@@ -4,8 +4,7 @@
 
 var assert = require('chai').assert;
 var mozWalker = require('../src/walker');
-var espree = require('espree');
-
+var parsers = require('./helpers/parsers');
 var modulePath = '../src/module';
 
 suite('module:', function () {
@@ -343,2707 +342,2715 @@ suite('module:', function () {
             }, mozWalker).dependencies);
         });
 
-        suite('function call:', function () {
-            var report;
+        parsers.forEach(function (parserName, parser, options) {
+            suite('function call:', function () {
+                var report;
+
+                setup(function () {
+                    report = escomplex.analyse(parser.parse('parseInt("10", 10);', options), mozWalker);
+                });
+
+                teardown(function () {
+                    report = undefined;
+                });
+
+                test('aggregate has correct physical lines of code', function () {
+                    assert.strictEqual(report.aggregate.sloc.physical, 1);
+                });
+
+                test('aggregate has correct logical lines of code', function () {
+                    assert.strictEqual(report.aggregate.sloc.logical, 1);
+                });
+
+                test('aggregate has correct cyclomatic complexity', function () {
+                    assert.strictEqual(report.aggregate.cyclomatic, 1);
+                });
+
+                test('aggregate has correct cyclomatic complexity density', function () {
+                    assert.strictEqual(report.aggregate.cyclomaticDensity, 100);
+                });
+
+                test('functions is empty', function () {
+                    assert.lengthOf(report.functions, 0);
+                });
+
+                test('aggregate has correct Halstead total operators', function () {
+                    assert.strictEqual(report.aggregate.halstead.operators.total, 1);
+                });
+
+                test('aggregate has correct Halstead distinct operators', function () {
+                    assert.strictEqual(report.aggregate.halstead.operators.distinct, 1);
+                });
+
+                test('aggregate has correct Halstead total operands', function () {
+                    assert.strictEqual(report.aggregate.halstead.operands.total, 3);
+                });
+
+                test('aggregate has correct Halstead distinct operands', function () {
+                    assert.strictEqual(report.aggregate.halstead.operands.distinct, 3);
+                });
+
+                test('aggregate has correct Halstead operator identifier length', function () {
+                    assert.lengthOf(
+                        report.aggregate.halstead.operators.identifiers,
+                        report.aggregate.halstead.operators.distinct
+                    );
+                });
+
+                test('aggregate has correct Halstead operand identifier length', function () {
+                    assert.lengthOf(
+                        report.aggregate.halstead.operands.identifiers,
+                        report.aggregate.halstead.operands.distinct
+                    );
+                });
+
+                test('aggregate has correct Halstead length', function () {
+                    assert.strictEqual(report.aggregate.halstead.length, 4);
+                });
+
+                test('aggregate has correct Halstead vocabulary', function () {
+                    assert.strictEqual(report.aggregate.halstead.vocabulary, 4);
+                });
+
+                test('aggregate has correct Halstead difficulty', function () {
+                    assert.strictEqual(report.aggregate.halstead.difficulty, 0.5);
+                });
+
+                test('aggregate has correct Halstead volume', function () {
+                    assert.strictEqual(report.aggregate.halstead.volume, 8);
+                });
+
+                test('aggregate has correct Halstead effort', function () {
+                    assert.strictEqual(report.aggregate.halstead.effort, 4);
+                });
+
+                test('aggregate has correct Halstead bugs', function () {
+                    assert.strictEqual(Math.round(report.aggregate.halstead.bugs), 0);
+                });
+
+                test('aggregate has correct Halstead time', function () {
+                    assert.strictEqual(Math.round(report.aggregate.halstead.time), 0);
+                });
+
+                test('maintainability index is correct', function () {
+                    assert.strictEqual(Math.round(report.maintainability), 166);
+                });
+
+                test('aggregate has correct parameter count', function () {
+                    assert.strictEqual(report.aggregate.params, 0);
+                });
+
+                test('mean logical LOC is correct', function () {
+                    assert.strictEqual(report.loc, 1);
+                });
+
+                test('mean cyclomatic complexity is correct', function () {
+                    assert.strictEqual(report.cyclomatic, 1);
+                });
+
+                test('mean Halstead effort is correct', function () {
+                    assert.strictEqual(report.effort, 4);
+                });
+
+                test('mean parameter count is correct', function () {
+                    assert.strictEqual(report.params, 0);
+                });
+
+                test('dependencies is correct', function () {
+                    assert.lengthOf(report.dependencies, 0);
+                });
+            });
+
+            suite('condition:', function () {
+                var report;
+
+                setup(function () {
+                    report = escomplex.analyse(parser.parse('if (true) { "foo"; }', options), mozWalker);
+                });
+
+                teardown(function () {
+                    report = undefined;
+                });
+
+                test('aggregate has correct physical lines of code', function () {
+                    assert.strictEqual(report.aggregate.sloc.physical, 1);
+                });
 
-            setup(function () {
-                report = escomplex.analyse(espree.parse('parseInt("10", 10);', { loc: true }), mozWalker);
-            });
-
-            teardown(function () {
-                report = undefined;
-            });
-
-            test('aggregate has correct physical lines of code', function () {
-                assert.strictEqual(report.aggregate.sloc.physical, 1);
-            });
-
-            test('aggregate has correct logical lines of code', function () {
-                assert.strictEqual(report.aggregate.sloc.logical, 1);
-            });
-
-            test('aggregate has correct cyclomatic complexity', function () {
-                assert.strictEqual(report.aggregate.cyclomatic, 1);
-            });
-
-            test('aggregate has correct cyclomatic complexity density', function () {
-                assert.strictEqual(report.aggregate.cyclomaticDensity, 100);
-            });
-
-            test('functions is empty', function () {
-                assert.lengthOf(report.functions, 0);
-            });
-
-            test('aggregate has correct Halstead total operators', function () {
-                assert.strictEqual(report.aggregate.halstead.operators.total, 1);
-            });
-
-            test('aggregate has correct Halstead distinct operators', function () {
-                assert.strictEqual(report.aggregate.halstead.operators.distinct, 1);
-            });
-
-            test('aggregate has correct Halstead total operands', function () {
-                assert.strictEqual(report.aggregate.halstead.operands.total, 3);
-            });
-
-            test('aggregate has correct Halstead distinct operands', function () {
-                assert.strictEqual(report.aggregate.halstead.operands.distinct, 3);
-            });
-
-            test('aggregate has correct Halstead operator identifier length', function () {
-                assert.lengthOf(
-                    report.aggregate.halstead.operators.identifiers,
-                    report.aggregate.halstead.operators.distinct
-                );
-            });
-
-            test('aggregate has correct Halstead operand identifier length', function () {
-                assert.lengthOf(
-                    report.aggregate.halstead.operands.identifiers,
-                    report.aggregate.halstead.operands.distinct
-                );
-            });
-
-            test('aggregate has correct Halstead length', function () {
-                assert.strictEqual(report.aggregate.halstead.length, 4);
-            });
-
-            test('aggregate has correct Halstead vocabulary', function () {
-                assert.strictEqual(report.aggregate.halstead.vocabulary, 4);
-            });
-
-            test('aggregate has correct Halstead difficulty', function () {
-                assert.strictEqual(report.aggregate.halstead.difficulty, 0.5);
-            });
-
-            test('aggregate has correct Halstead volume', function () {
-                assert.strictEqual(report.aggregate.halstead.volume, 8);
-            });
-
-            test('aggregate has correct Halstead effort', function () {
-                assert.strictEqual(report.aggregate.halstead.effort, 4);
-            });
-
-            test('aggregate has correct Halstead bugs', function () {
-                assert.strictEqual(Math.round(report.aggregate.halstead.bugs), 0);
-            });
-
-            test('aggregate has correct Halstead time', function () {
-                assert.strictEqual(Math.round(report.aggregate.halstead.time), 0);
-            });
-
-            test('maintainability index is correct', function () {
-                assert.strictEqual(Math.round(report.maintainability), 166);
-            });
-
-            test('aggregate has correct parameter count', function () {
-                assert.strictEqual(report.aggregate.params, 0);
-            });
-
-            test('mean logical LOC is correct', function () {
-                assert.strictEqual(report.loc, 1);
-            });
-
-            test('mean cyclomatic complexity is correct', function () {
-                assert.strictEqual(report.cyclomatic, 1);
-            });
-
-            test('mean Halstead effort is correct', function () {
-                assert.strictEqual(report.effort, 4);
-            });
-
-            test('mean parameter count is correct', function () {
-                assert.strictEqual(report.params, 0);
-            });
-
-            test('dependencies is correct', function () {
-                assert.lengthOf(report.dependencies, 0);
-            });
-        });
-
-        suite('condition:', function () {
-            var report;
-
-            setup(function () {
-                report = escomplex.analyse(espree.parse('if (true) { "foo"; }', { loc: true }), mozWalker);
-            });
-
-            teardown(function () {
-                report = undefined;
-            });
-
-            test('aggregate has correct physical lines of code', function () {
-                assert.strictEqual(report.aggregate.sloc.physical, 1);
-            });
-
-            test('aggregate has correct logical lines of code', function () {
-                assert.strictEqual(report.aggregate.sloc.logical, 2);
-            });
-
-            test('aggregate has correct cyclomatic complexity', function () {
-                assert.strictEqual(report.aggregate.cyclomatic, 2);
-            });
-
-            test('aggregate has correct cyclomatic complexity density', function () {
-                assert.strictEqual(report.aggregate.cyclomaticDensity, 100);
-            });
-
-            test('functions is empty', function () {
-                assert.lengthOf(report.functions, 0);
-            });
-
-            test('aggregate has correct Halstead total operators', function () {
-                assert.strictEqual(report.aggregate.halstead.operators.total, 1);
-            });
-
-            test('aggregate has correct Halstead distinct operators', function () {
-                assert.strictEqual(report.aggregate.halstead.operators.distinct, 1);
-            });
-
-            test('aggregate has correct Halstead total operands', function () {
-                assert.strictEqual(report.aggregate.halstead.operands.total, 2);
-            });
-
-            test('aggregate has correct Halstead distinct operands', function () {
-                assert.strictEqual(report.aggregate.halstead.operands.distinct, 2);
-            });
-
-            test('aggregate has correct Halstead operator identifier length', function () {
-                assert.lengthOf(
-                    report.aggregate.halstead.operators.identifiers,
-                    report.aggregate.halstead.operators.distinct
-                );
-            });
-
-            test('aggregate has correct Halstead operand identifier length', function () {
-                assert.lengthOf(
-                    report.aggregate.halstead.operands.identifiers,
-                    report.aggregate.halstead.operands.distinct
-                );
-            });
-
-            test('aggregate has correct Halstead length', function () {
-                assert.strictEqual(report.aggregate.halstead.length, 3);
-            });
-
-            test('aggregate has correct Halstead vocabulary', function () {
-                assert.strictEqual(report.aggregate.halstead.vocabulary, 3);
-            });
-
-            test('aggregate has correct Halstead difficulty', function () {
-                assert.strictEqual(report.aggregate.halstead.difficulty, 0.5);
-            });
-
-            test('aggregate has correct Halstead volume', function () {
-                assert.strictEqual(Math.round(report.aggregate.halstead.volume), 5);
-            });
-
-            test('aggregate has correct Halstead effort', function () {
-                assert.strictEqual(Math.round(report.aggregate.halstead.effort), 2);
-            });
-
-            test('aggregate has correct Halstead bugs', function () {
-                assert.strictEqual(Math.round(report.aggregate.halstead.bugs), 0);
-            });
-
-            test('aggregate has correct Halstead time', function () {
-                assert.strictEqual(Math.round(report.aggregate.halstead.time), 0);
-            });
-
-            test('maintainability index is correct', function () {
-                assert.strictEqual(Math.round(report.maintainability), 157);
-            });
+                test('aggregate has correct logical lines of code', function () {
+                    assert.strictEqual(report.aggregate.sloc.logical, 2);
+                });
 
-            test('mean logical LOC is correct', function () {
-                assert.strictEqual(report.loc, 2);
-            });
-
-            test('mean cyclomatic complexity is correct', function () {
-                assert.strictEqual(report.cyclomatic, 2);
-            });
-
-            test('mean Halstead effort is correct', function () {
-                assert.strictEqual(report.effort, 2.3774437510817346);
-            });
-
-            test('mean parameter count is correct', function () {
-                assert.strictEqual(report.params, 0);
-            });
-
-            test('dependencies is correct', function () {
-                assert.lengthOf(report.dependencies, 0);
-            });
-        });
-
-        suite('condition with alternate:', function () {
-            var report;
-
-            setup(function () {
-                report = escomplex.analyse(espree.parse('if (true) { "foo"; } else { "bar"; }', { loc: true }), mozWalker);
-            });
-
-            teardown(function () {
-                report = undefined;
-            });
-
-            test('aggregate has correct physical lines of code', function () {
-                assert.strictEqual(report.aggregate.sloc.physical, 1);
-            });
-
-            test('aggregate has correct logical lines of code', function () {
-                assert.strictEqual(report.aggregate.sloc.logical, 4);
-            });
-
-            test('aggregate has correct cyclomatic complexity', function () {
-                assert.strictEqual(report.aggregate.cyclomatic, 2);
-            });
-
-            test('functions is empty', function () {
-                assert.lengthOf(report.functions, 0);
-            });
-
-            test('aggregate has correct Halstead total operators', function () {
-                assert.strictEqual(report.aggregate.halstead.operators.total, 2);
-            });
-
-            test('aggregate has correct Halstead distinct operators', function () {
-                assert.strictEqual(report.aggregate.halstead.operators.distinct, 2);
-            });
+                test('aggregate has correct cyclomatic complexity', function () {
+                    assert.strictEqual(report.aggregate.cyclomatic, 2);
+                });
 
-            test('aggregate has correct Halstead total operands', function () {
-                assert.strictEqual(report.aggregate.halstead.operands.total, 3);
-            });
-
-            test('aggregate has correct Halstead distinct operands', function () {
-                assert.strictEqual(report.aggregate.halstead.operands.distinct, 3);
-            });
+                test('aggregate has correct cyclomatic complexity density', function () {
+                    assert.strictEqual(report.aggregate.cyclomaticDensity, 100);
+                });
 
-            test('aggregate has correct Halstead operator identifier length', function () {
-                assert.lengthOf(
-                    report.aggregate.halstead.operators.identifiers,
-                    report.aggregate.halstead.operators.distinct
-                );
-            });
+                test('functions is empty', function () {
+                    assert.lengthOf(report.functions, 0);
+                });
 
-            test('aggregate has correct Halstead operand identifier length', function () {
-                assert.lengthOf(
-                    report.aggregate.halstead.operands.identifiers,
-                    report.aggregate.halstead.operands.distinct
-                );
-            });
+                test('aggregate has correct Halstead total operators', function () {
+                    assert.strictEqual(report.aggregate.halstead.operators.total, 1);
+                });
 
-            test('aggregate has correct Halstead length', function () {
-                assert.strictEqual(report.aggregate.halstead.length, 5);
-            });
+                test('aggregate has correct Halstead distinct operators', function () {
+                    assert.strictEqual(report.aggregate.halstead.operators.distinct, 1);
+                });
 
-            test('aggregate has correct Halstead vocabulary', function () {
-                assert.strictEqual(report.aggregate.halstead.vocabulary, 5);
-            });
+                test('aggregate has correct Halstead total operands', function () {
+                    assert.strictEqual(report.aggregate.halstead.operands.total, 2);
+                });
 
-            test('aggregate has correct Halstead difficulty', function () {
-                assert.strictEqual(report.aggregate.halstead.difficulty, 1);
-            });
+                test('aggregate has correct Halstead distinct operands', function () {
+                    assert.strictEqual(report.aggregate.halstead.operands.distinct, 2);
+                });
 
-            test('aggregate has correct Halstead volume', function () {
-                assert.strictEqual(Math.round(report.aggregate.halstead.volume), 12);
-            });
+                test('aggregate has correct Halstead operator identifier length', function () {
+                    assert.lengthOf(
+                        report.aggregate.halstead.operators.identifiers,
+                        report.aggregate.halstead.operators.distinct
+                    );
+                });
 
-            test('aggregate has correct Halstead effort', function () {
-                assert.strictEqual(Math.round(report.aggregate.halstead.effort), 12);
-            });
+                test('aggregate has correct Halstead operand identifier length', function () {
+                    assert.lengthOf(
+                        report.aggregate.halstead.operands.identifiers,
+                        report.aggregate.halstead.operands.distinct
+                    );
+                });
 
-            test('aggregate has correct Halstead bugs', function () {
-                assert.strictEqual(Math.round(report.aggregate.halstead.bugs), 0);
-            });
+                test('aggregate has correct Halstead length', function () {
+                    assert.strictEqual(report.aggregate.halstead.length, 3);
+                });
 
-            test('aggregate has correct Halstead time', function () {
-                assert.strictEqual(Math.round(report.aggregate.halstead.time), 1);
-            });
-        });
+                test('aggregate has correct Halstead vocabulary', function () {
+                    assert.strictEqual(report.aggregate.halstead.vocabulary, 3);
+                });
+
+                test('aggregate has correct Halstead difficulty', function () {
+                    assert.strictEqual(report.aggregate.halstead.difficulty, 0.5);
+                });
+
+                test('aggregate has correct Halstead volume', function () {
+                    assert.strictEqual(Math.round(report.aggregate.halstead.volume), 5);
+                });
+
+                test('aggregate has correct Halstead effort', function () {
+                    assert.strictEqual(Math.round(report.aggregate.halstead.effort), 2);
+                });
+
+                test('aggregate has correct Halstead bugs', function () {
+                    assert.strictEqual(Math.round(report.aggregate.halstead.bugs), 0);
+                });
+
+                test('aggregate has correct Halstead time', function () {
+                    assert.strictEqual(Math.round(report.aggregate.halstead.time), 0);
+                });
+
+                test('maintainability index is correct', function () {
+                    assert.strictEqual(Math.round(report.maintainability), 157);
+                });
+
+                test('mean logical LOC is correct', function () {
+                    assert.strictEqual(report.loc, 2);
+                });
+
+                test('mean cyclomatic complexity is correct', function () {
+                    assert.strictEqual(report.cyclomatic, 2);
+                });
 
-        suite('dual condition:', function () {
-            var report;
+                test('mean Halstead effort is correct', function () {
+                    assert.strictEqual(report.effort, 2.3774437510817346);
+                });
 
-            setup(function () {
-                report = escomplex.analyse(espree.parse('if (true) { "foo"; } if (false) { "bar"; }', { loc: true }), mozWalker);
-            });
+                test('mean parameter count is correct', function () {
+                    assert.strictEqual(report.params, 0);
+                });
 
-            teardown(function () {
-                report = undefined;
+                test('dependencies is correct', function () {
+                    assert.lengthOf(report.dependencies, 0);
+                });
             });
 
-            test('aggregate has correct logical lines of code', function () {
-                assert.strictEqual(report.aggregate.sloc.logical, 4);
-            });
+            suite('condition with alternate:', function () {
+                var report;
 
-            test('aggregate has correct cyclomatic complexity', function () {
-                assert.strictEqual(report.aggregate.cyclomatic, 3);
-            });
+                setup(function () {
+                    report = escomplex.analyse(parser.parse('if (true) { "foo"; } else { "bar"; }', options), mozWalker);
+                });
 
-            test('aggregate has correct Halstead total operators', function () {
-                assert.strictEqual(report.aggregate.halstead.operators.total, 2);
-            });
+                teardown(function () {
+                    report = undefined;
+                });
 
-            test('aggregate has correct Halstead distinct operators', function () {
-                assert.strictEqual(report.aggregate.halstead.operators.distinct, 1);
-            });
+                test('aggregate has correct physical lines of code', function () {
+                    assert.strictEqual(report.aggregate.sloc.physical, 1);
+                });
 
-            test('aggregate has correct Halstead total operands', function () {
-                assert.strictEqual(report.aggregate.halstead.operands.total, 4);
-            });
+                test('aggregate has correct logical lines of code', function () {
+                    assert.strictEqual(report.aggregate.sloc.logical, 4);
+                });
 
-            test('aggregate has correct Halstead distinct operands', function () {
-                assert.strictEqual(report.aggregate.halstead.operands.distinct, 4);
-            });
+                test('aggregate has correct cyclomatic complexity', function () {
+                    assert.strictEqual(report.aggregate.cyclomatic, 2);
+                });
 
-            test('aggregate has correct Halstead operator identifier length', function () {
-                assert.lengthOf(
-                    report.aggregate.halstead.operators.identifiers,
-                    report.aggregate.halstead.operators.distinct
-                );
-            });
+                test('functions is empty', function () {
+                    assert.lengthOf(report.functions, 0);
+                });
+
+                test('aggregate has correct Halstead total operators', function () {
+                    assert.strictEqual(report.aggregate.halstead.operators.total, 2);
+                });
+
+                test('aggregate has correct Halstead distinct operators', function () {
+                    assert.strictEqual(report.aggregate.halstead.operators.distinct, 2);
+                });
+
+                test('aggregate has correct Halstead total operands', function () {
+                    assert.strictEqual(report.aggregate.halstead.operands.total, 3);
+                });
+
+                test('aggregate has correct Halstead distinct operands', function () {
+                    assert.strictEqual(report.aggregate.halstead.operands.distinct, 3);
+                });
+
+                test('aggregate has correct Halstead operator identifier length', function () {
+                    assert.lengthOf(
+                        report.aggregate.halstead.operators.identifiers,
+                        report.aggregate.halstead.operators.distinct
+                    );
+                });
+
+                test('aggregate has correct Halstead operand identifier length', function () {
+                    assert.lengthOf(
+                        report.aggregate.halstead.operands.identifiers,
+                        report.aggregate.halstead.operands.distinct
+                    );
+                });
+
+                test('aggregate has correct Halstead length', function () {
+                    assert.strictEqual(report.aggregate.halstead.length, 5);
+                });
+
+                test('aggregate has correct Halstead vocabulary', function () {
+                    assert.strictEqual(report.aggregate.halstead.vocabulary, 5);
+                });
+
+                test('aggregate has correct Halstead difficulty', function () {
+                    assert.strictEqual(report.aggregate.halstead.difficulty, 1);
+                });
+
+                test('aggregate has correct Halstead volume', function () {
+                    assert.strictEqual(Math.round(report.aggregate.halstead.volume), 12);
+                });
+
+                test('aggregate has correct Halstead effort', function () {
+                    assert.strictEqual(Math.round(report.aggregate.halstead.effort), 12);
+                });
+
+                test('aggregate has correct Halstead bugs', function () {
+                    assert.strictEqual(Math.round(report.aggregate.halstead.bugs), 0);
+                });
+
+                test('aggregate has correct Halstead time', function () {
+                    assert.strictEqual(Math.round(report.aggregate.halstead.time), 1);
+                });
+            });
+
+            suite('dual condition:', function () {
+                var report;
+
+                setup(function () {
+                    report = escomplex.analyse(parser.parse('if (true) { "foo"; } if (false) { "bar"; }', options), mozWalker);
+                });
+
+                teardown(function () {
+                    report = undefined;
+                });
+
+                test('aggregate has correct logical lines of code', function () {
+                    assert.strictEqual(report.aggregate.sloc.logical, 4);
+                });
+
+                test('aggregate has correct cyclomatic complexity', function () {
+                    assert.strictEqual(report.aggregate.cyclomatic, 3);
+                });
+
+                test('aggregate has correct Halstead total operators', function () {
+                    assert.strictEqual(report.aggregate.halstead.operators.total, 2);
+                });
+
+                test('aggregate has correct Halstead distinct operators', function () {
+                    assert.strictEqual(report.aggregate.halstead.operators.distinct, 1);
+                });
+
+                test('aggregate has correct Halstead total operands', function () {
+                    assert.strictEqual(report.aggregate.halstead.operands.total, 4);
+                });
+
+                test('aggregate has correct Halstead distinct operands', function () {
+                    assert.strictEqual(report.aggregate.halstead.operands.distinct, 4);
+                });
+
+                test('aggregate has correct Halstead operator identifier length', function () {
+                    assert.lengthOf(
+                        report.aggregate.halstead.operators.identifiers,
+                        report.aggregate.halstead.operators.distinct
+                    );
+                });
 
-            test('aggregate has correct Halstead operand identifier length', function () {
-                assert.lengthOf(
-                    report.aggregate.halstead.operands.identifiers,
-                    report.aggregate.halstead.operands.distinct
-                );
-            });
+                test('aggregate has correct Halstead operand identifier length', function () {
+                    assert.lengthOf(
+                        report.aggregate.halstead.operands.identifiers,
+                        report.aggregate.halstead.operands.distinct
+                    );
+                });
 
-            test('aggregate has correct Halstead length', function () {
-                assert.strictEqual(report.aggregate.halstead.length, 6);
-            });
+                test('aggregate has correct Halstead length', function () {
+                    assert.strictEqual(report.aggregate.halstead.length, 6);
+                });
 
-            test('aggregate has correct Halstead vocabulary', function () {
-                assert.strictEqual(report.aggregate.halstead.vocabulary, 5);
-            });
+                test('aggregate has correct Halstead vocabulary', function () {
+                    assert.strictEqual(report.aggregate.halstead.vocabulary, 5);
+                });
 
-            test('aggregate has correct Halstead difficulty', function () {
-                assert.strictEqual(report.aggregate.halstead.difficulty, 0.5);
+                test('aggregate has correct Halstead difficulty', function () {
+                    assert.strictEqual(report.aggregate.halstead.difficulty, 0.5);
+                });
             });
-        });
 
-        suite('alternate dual condition:', function () {
-            var report;
+            suite('alternate dual condition:', function () {
+                var report;
 
-            setup(function () {
-                report = escomplex.analyse(espree.parse('if (true) { "foo"; } else if (false) { "bar"; }', { loc: true }), mozWalker);
-            });
+                setup(function () {
+                    report = escomplex.analyse(parser.parse('if (true) { "foo"; } else if (false) { "bar"; }', options), mozWalker);
+                });
 
-            teardown(function () {
-                report = undefined;
-            });
+                teardown(function () {
+                    report = undefined;
+                });
 
-            test('aggregate has correct logical lines of code', function () {
-                assert.strictEqual(report.aggregate.sloc.logical, 5);
-            });
+                test('aggregate has correct logical lines of code', function () {
+                    assert.strictEqual(report.aggregate.sloc.logical, 5);
+                });
 
-            test('aggregate has correct cyclomatic complexity', function () {
-                assert.strictEqual(report.aggregate.cyclomatic, 3);
-            });
+                test('aggregate has correct cyclomatic complexity', function () {
+                    assert.strictEqual(report.aggregate.cyclomatic, 3);
+                });
 
-            test('aggregate has correct Halstead total operators', function () {
-                assert.strictEqual(report.aggregate.halstead.operators.total, 3);
-            });
+                test('aggregate has correct Halstead total operators', function () {
+                    assert.strictEqual(report.aggregate.halstead.operators.total, 3);
+                });
 
-            test('aggregate has correct Halstead distinct operators', function () {
-                assert.strictEqual(report.aggregate.halstead.operators.distinct, 2);
-            });
+                test('aggregate has correct Halstead distinct operators', function () {
+                    assert.strictEqual(report.aggregate.halstead.operators.distinct, 2);
+                });
 
-            test('aggregate has correct Halstead total operands', function () {
-                assert.strictEqual(report.aggregate.halstead.operands.total, 4);
-            });
+                test('aggregate has correct Halstead total operands', function () {
+                    assert.strictEqual(report.aggregate.halstead.operands.total, 4);
+                });
 
-            test('aggregate has correct Halstead distinct operands', function () {
-                assert.strictEqual(report.aggregate.halstead.operands.distinct, 4);
-            });
+                test('aggregate has correct Halstead distinct operands', function () {
+                    assert.strictEqual(report.aggregate.halstead.operands.distinct, 4);
+                });
 
-            test('aggregate has correct Halstead operator identifier length', function () {
-                assert.lengthOf(
-                    report.aggregate.halstead.operators.identifiers,
-                    report.aggregate.halstead.operators.distinct
-                );
-            });
+                test('aggregate has correct Halstead operator identifier length', function () {
+                    assert.lengthOf(
+                        report.aggregate.halstead.operators.identifiers,
+                        report.aggregate.halstead.operators.distinct
+                    );
+                });
 
-            test('aggregate has correct Halstead operand identifier length', function () {
-                assert.lengthOf(
-                    report.aggregate.halstead.operands.identifiers,
-                    report.aggregate.halstead.operands.distinct
-                );
+                test('aggregate has correct Halstead operand identifier length', function () {
+                    assert.lengthOf(
+                        report.aggregate.halstead.operands.identifiers,
+                        report.aggregate.halstead.operands.distinct
+                    );
+                });
             });
-        });
 
-        suite('nested condition:', function () {
-            var report;
+            suite('nested condition:', function () {
+                var report;
 
-            setup(function () {
-                report = escomplex.analyse(espree.parse('if (true) { "foo"; if (false) { "bar"; } }', { loc: true }), mozWalker);
-            });
+                setup(function () {
+                    report = escomplex.analyse(parser.parse('if (true) { "foo"; if (false) { "bar"; } }', options), mozWalker);
+                });
 
-            teardown(function () {
-                report = undefined;
-            });
+                teardown(function () {
+                    report = undefined;
+                });
 
-            test('aggregate has correct logical lines of code', function () {
-                assert.strictEqual(report.aggregate.sloc.logical, 4);
-            });
+                test('aggregate has correct logical lines of code', function () {
+                    assert.strictEqual(report.aggregate.sloc.logical, 4);
+                });
 
-            test('aggregate has correct cyclomatic complexity', function () {
-                assert.strictEqual(report.aggregate.cyclomatic, 3);
+                test('aggregate has correct cyclomatic complexity', function () {
+                    assert.strictEqual(report.aggregate.cyclomatic, 3);
+                });
             });
-        });
 
-        suite('switch statement:', function () {
-            var report;
+            suite('switch statement:', function () {
+                var report;
 
-            setup(function () {
-                report = escomplex.analyse(espree.parse('switch (Date.now()) { case 1: "foo"; break; case 2: "bar"; break; default: "baz"; }', { loc: true }), mozWalker);
-            });
+                setup(function () {
+                    report = escomplex.analyse(parser.parse('switch (Date.now()) { case 1: "foo"; break; case 2: "bar"; break; default: "baz"; }', options), mozWalker);
+                });
 
-            teardown(function () {
-                report = undefined;
-            });
+                teardown(function () {
+                    report = undefined;
+                });
 
-            test('aggregate has correct logical lines of code', function () {
-                assert.strictEqual(report.aggregate.sloc.logical, 9);
-            });
+                test('aggregate has correct logical lines of code', function () {
+                    assert.strictEqual(report.aggregate.sloc.logical, 9);
+                });
 
-            test('aggregate has correct cyclomatic complexity', function () {
-                assert.strictEqual(report.aggregate.cyclomatic, 3);
-            });
+                test('aggregate has correct cyclomatic complexity', function () {
+                    assert.strictEqual(report.aggregate.cyclomatic, 3);
+                });
 
-            test('aggregate has correct cyclomatic complexity density', function () {
-                assert.isTrue(report.aggregate.cyclomaticDensity > 33.3);
-                assert.isTrue(report.aggregate.cyclomaticDensity < 33.4);
-            });
+                test('aggregate has correct cyclomatic complexity density', function () {
+                    assert.isTrue(report.aggregate.cyclomaticDensity > 33.3);
+                    assert.isTrue(report.aggregate.cyclomaticDensity < 33.4);
+                });
 
-            test('functions is empty', function () {
-                assert.lengthOf(report.functions, 0);
-            });
+                test('functions is empty', function () {
+                    assert.lengthOf(report.functions, 0);
+                });
 
-            test('aggregate has correct Halstead total operators', function () {
-                assert.strictEqual(report.aggregate.halstead.operators.total, 8);
-            });
+                test('aggregate has correct Halstead total operators', function () {
+                    assert.strictEqual(report.aggregate.halstead.operators.total, 8);
+                });
 
-            test('aggregate has correct Halstead distinct operators', function () {
-                assert.strictEqual(report.aggregate.halstead.operators.distinct, 6);
-            });
+                test('aggregate has correct Halstead distinct operators', function () {
+                    assert.strictEqual(report.aggregate.halstead.operators.distinct, 6);
+                });
 
-            test('aggregate has correct Halstead total operands', function () {
-                assert.strictEqual(report.aggregate.halstead.operands.total, 7);
-            });
+                test('aggregate has correct Halstead total operands', function () {
+                    assert.strictEqual(report.aggregate.halstead.operands.total, 7);
+                });
 
-            test('aggregate has correct Halstead distinct operands', function () {
-                assert.strictEqual(report.aggregate.halstead.operands.distinct, 7);
+                test('aggregate has correct Halstead distinct operands', function () {
+                    assert.strictEqual(report.aggregate.halstead.operands.distinct, 7);
+                });
             });
-        });
 
-        suite('switch statement with fall-through case:', function () {
-            var report;
+            suite('switch statement with fall-through case:', function () {
+                var report;
 
-            setup(function () {
-                report = escomplex.analyse(espree.parse('switch (Date.now()) { case 1: case 2: "foo"; break; default: "bar"; }', { loc: true }), mozWalker);
-            });
+                setup(function () {
+                    report = escomplex.analyse(parser.parse('switch (Date.now()) { case 1: case 2: "foo"; break; default: "bar"; }', options), mozWalker);
+                });
 
-            teardown(function () {
-                report = undefined;
-            });
+                teardown(function () {
+                    report = undefined;
+                });
 
-            test('aggregate has correct logical lines of code', function () {
-                assert.strictEqual(report.aggregate.sloc.logical, 7);
-            });
+                test('aggregate has correct logical lines of code', function () {
+                    assert.strictEqual(report.aggregate.sloc.logical, 7);
+                });
 
-            test('aggregate has correct cyclomatic complexity', function () {
-                assert.strictEqual(report.aggregate.cyclomatic, 3);
-            });
+                test('aggregate has correct cyclomatic complexity', function () {
+                    assert.strictEqual(report.aggregate.cyclomatic, 3);
+                });
 
-            test('functions is empty', function () {
-                assert.lengthOf(report.functions, 0);
-            });
+                test('functions is empty', function () {
+                    assert.lengthOf(report.functions, 0);
+                });
 
-            test('aggregate has correct Halstead total operators', function () {
-                assert.strictEqual(report.aggregate.halstead.operators.total, 7);
-            });
+                test('aggregate has correct Halstead total operators', function () {
+                    assert.strictEqual(report.aggregate.halstead.operators.total, 7);
+                });
 
-            test('aggregate has correct Halstead distinct operators', function () {
-                assert.strictEqual(report.aggregate.halstead.operators.distinct, 6);
-            });
+                test('aggregate has correct Halstead distinct operators', function () {
+                    assert.strictEqual(report.aggregate.halstead.operators.distinct, 6);
+                });
 
-            test('aggregate has correct Halstead total operands', function () {
-                assert.strictEqual(report.aggregate.halstead.operands.total, 6);
-            });
+                test('aggregate has correct Halstead total operands', function () {
+                    assert.strictEqual(report.aggregate.halstead.operands.total, 6);
+                });
 
-            test('aggregate has correct Halstead distinct operands', function () {
-                assert.strictEqual(report.aggregate.halstead.operands.distinct, 6);
+                test('aggregate has correct Halstead distinct operands', function () {
+                    assert.strictEqual(report.aggregate.halstead.operands.distinct, 6);
+                });
             });
-        });
 
-        suite('switch statement containing condition:', function () {
-            var report;
+            suite('switch statement containing condition:', function () {
+                var report;
 
-            setup(function () {
-                report = escomplex.analyse(espree.parse('switch (Date.now()) { case 1: "foo"; break; case 2: "bar"; break; default: if (true) { "baz"; } }', { loc: true }), mozWalker);
-            });
+                setup(function () {
+                    report = escomplex.analyse(parser.parse('switch (Date.now()) { case 1: "foo"; break; case 2: "bar"; break; default: if (true) { "baz"; } }', options), mozWalker);
+                });
 
-            teardown(function () {
-                report = undefined;
-            });
+                teardown(function () {
+                    report = undefined;
+                });
 
-            test('aggregate has correct logical lines of code', function () {
-                assert.strictEqual(report.aggregate.sloc.logical, 10);
-            });
+                test('aggregate has correct logical lines of code', function () {
+                    assert.strictEqual(report.aggregate.sloc.logical, 10);
+                });
 
-            test('aggregate has correct cyclomatic complexity', function () {
-                assert.strictEqual(report.aggregate.cyclomatic, 4);
-            });
+                test('aggregate has correct cyclomatic complexity', function () {
+                    assert.strictEqual(report.aggregate.cyclomatic, 4);
+                });
 
-            test('functions is empty', function () {
-                assert.lengthOf(report.functions, 0);
-            });
+                test('functions is empty', function () {
+                    assert.lengthOf(report.functions, 0);
+                });
 
-            test('aggregate has correct Halstead total operators', function () {
-                assert.strictEqual(report.aggregate.halstead.operators.total, 9);
-            });
+                test('aggregate has correct Halstead total operators', function () {
+                    assert.strictEqual(report.aggregate.halstead.operators.total, 9);
+                });
 
-            test('aggregate has correct Halstead distinct operators', function () {
-                assert.strictEqual(report.aggregate.halstead.operators.distinct, 7);
-            });
+                test('aggregate has correct Halstead distinct operators', function () {
+                    assert.strictEqual(report.aggregate.halstead.operators.distinct, 7);
+                });
 
-            test('aggregate has correct Halstead total operands', function () {
-                assert.strictEqual(report.aggregate.halstead.operands.total, 8);
-            });
+                test('aggregate has correct Halstead total operands', function () {
+                    assert.strictEqual(report.aggregate.halstead.operands.total, 8);
+                });
 
-            test('aggregate has correct Halstead distinct operands', function () {
-                assert.strictEqual(report.aggregate.halstead.operands.distinct, 8);
+                test('aggregate has correct Halstead distinct operands', function () {
+                    assert.strictEqual(report.aggregate.halstead.operands.distinct, 8);
+                });
             });
-        });
 
-        suite('for loop:', function () {
-            var report;
+            suite('for loop:', function () {
+                var report;
 
-            setup(function () {
-                report = escomplex.analyse(espree.parse('var i; for (i = 0; i < 10; i += 1) { "foo"; }', { loc: true }), mozWalker);
-            });
+                setup(function () {
+                    report = escomplex.analyse(parser.parse('var i; for (i = 0; i < 10; i += 1) { "foo"; }', options), mozWalker);
+                });
 
-            teardown(function () {
-                report = undefined;
-            });
+                teardown(function () {
+                    report = undefined;
+                });
 
-            test('aggregate has correct logical lines of code', function () {
-                assert.strictEqual(report.aggregate.sloc.logical, 3);
-            });
+                test('aggregate has correct logical lines of code', function () {
+                    assert.strictEqual(report.aggregate.sloc.logical, 3);
+                });
 
-            test('aggregate has correct cyclomatic complexity', function () {
-                assert.strictEqual(report.aggregate.cyclomatic, 2);
-            });
+                test('aggregate has correct cyclomatic complexity', function () {
+                    assert.strictEqual(report.aggregate.cyclomatic, 2);
+                });
 
-            test('functions is empty', function () {
-                assert.lengthOf(report.functions, 0);
-            });
+                test('functions is empty', function () {
+                    assert.lengthOf(report.functions, 0);
+                });
 
-            test('aggregate has correct Halstead total operators', function () {
-                assert.strictEqual(report.aggregate.halstead.operators.total, 5);
-            });
+                test('aggregate has correct Halstead total operators', function () {
+                    assert.strictEqual(report.aggregate.halstead.operators.total, 5);
+                });
 
-            test('aggregate has correct Halstead distinct operators', function () {
-                assert.strictEqual(report.aggregate.halstead.operators.distinct, 5);
-            });
+                test('aggregate has correct Halstead distinct operators', function () {
+                    assert.strictEqual(report.aggregate.halstead.operators.distinct, 5);
+                });
 
-            test('aggregate has correct Halstead total operands', function () {
-                assert.strictEqual(report.aggregate.halstead.operands.total, 8);
-            });
+                test('aggregate has correct Halstead total operands', function () {
+                    assert.strictEqual(report.aggregate.halstead.operands.total, 8);
+                });
 
-            test('aggregate has correct Halstead distinct operands', function () {
-                assert.strictEqual(report.aggregate.halstead.operands.distinct, 5);
-            });
+                test('aggregate has correct Halstead distinct operands', function () {
+                    assert.strictEqual(report.aggregate.halstead.operands.distinct, 5);
+                });
 
-            test('aggregate has correct Halstead length', function () {
-                assert.strictEqual(report.aggregate.halstead.length, 13);
-            });
+                test('aggregate has correct Halstead length', function () {
+                    assert.strictEqual(report.aggregate.halstead.length, 13);
+                });
 
-            test('aggregate has correct Halstead vocabulary', function () {
-                assert.strictEqual(report.aggregate.halstead.vocabulary, 10);
-            });
+                test('aggregate has correct Halstead vocabulary', function () {
+                    assert.strictEqual(report.aggregate.halstead.vocabulary, 10);
+                });
 
-            test('aggregate has correct Halstead difficulty', function () {
-                assert.strictEqual(report.aggregate.halstead.difficulty, 4);
+                test('aggregate has correct Halstead difficulty', function () {
+                    assert.strictEqual(report.aggregate.halstead.difficulty, 4);
+                });
             });
-        });
 
-        suite('for loop containing condition:', function () {
-            var report;
+            suite('for loop containing condition:', function () {
+                var report;
 
-            setup(function () {
-                report = escomplex.analyse(espree.parse('var i; for (i = 0; i < 10; i += 1) { if (true) { "foo"; } }', { loc: true }), mozWalker);
-            });
+                setup(function () {
+                    report = escomplex.analyse(parser.parse('var i; for (i = 0; i < 10; i += 1) { if (true) { "foo"; } }', options), mozWalker);
+                });
 
-            teardown(function () {
-                report = undefined;
-            });
+                teardown(function () {
+                    report = undefined;
+                });
 
-            test('aggregate has correct cyclomatic complexity', function () {
-                assert.strictEqual(report.aggregate.cyclomatic, 3);
-            });
+                test('aggregate has correct cyclomatic complexity', function () {
+                    assert.strictEqual(report.aggregate.cyclomatic, 3);
+                });
 
-            test('aggregate has correct Halstead total operators', function () {
-                assert.strictEqual(report.aggregate.halstead.operators.total, 6);
-            });
+                test('aggregate has correct Halstead total operators', function () {
+                    assert.strictEqual(report.aggregate.halstead.operators.total, 6);
+                });
 
-            test('aggregate has correct Halstead distinct operators', function () {
-                assert.strictEqual(report.aggregate.halstead.operators.distinct, 6);
-            });
+                test('aggregate has correct Halstead distinct operators', function () {
+                    assert.strictEqual(report.aggregate.halstead.operators.distinct, 6);
+                });
 
-            test('aggregate has correct Halstead total operands', function () {
-                assert.strictEqual(report.aggregate.halstead.operands.total, 9);
-            });
+                test('aggregate has correct Halstead total operands', function () {
+                    assert.strictEqual(report.aggregate.halstead.operands.total, 9);
+                });
 
-            test('aggregate has correct Halstead distinct operands', function () {
-                assert.strictEqual(report.aggregate.halstead.operands.distinct, 6);
+                test('aggregate has correct Halstead distinct operands', function () {
+                    assert.strictEqual(report.aggregate.halstead.operands.distinct, 6);
+                });
             });
-        });
 
-        suite('for...in loop:', function () {
-            var report;
+            suite('for...in loop:', function () {
+                var report;
 
-            setup(function () {
-                report = escomplex.analyse(espree.parse('var property; for (property in { foo: "bar", baz: "qux" }) { "wibble"; }', { loc: true }), mozWalker);
-            });
+                setup(function () {
+                    report = escomplex.analyse(parser.parse('var property; for (property in { foo: "bar", baz: "qux" }) { "wibble"; }', options), mozWalker);
+                });
 
-            teardown(function () {
-                report = undefined;
-            });
+                teardown(function () {
+                    report = undefined;
+                });
 
-            test('aggregate has correct logical lines of code', function () {
-                assert.strictEqual(report.aggregate.sloc.logical, 5);
-            });
+                test('aggregate has correct logical lines of code', function () {
+                    assert.strictEqual(report.aggregate.sloc.logical, 5);
+                });
 
-            test('aggregate has correct cyclomatic complexity', function () {
-                assert.strictEqual(report.aggregate.cyclomatic, 1);
-            });
+                test('aggregate has correct cyclomatic complexity', function () {
+                    assert.strictEqual(report.aggregate.cyclomatic, 1);
+                });
 
-            test('functions is empty', function () {
-                assert.lengthOf(report.functions, 0);
-            });
+                test('functions is empty', function () {
+                    assert.lengthOf(report.functions, 0);
+                });
 
-            test('aggregate has correct Halstead total operators', function () {
-                assert.strictEqual(report.aggregate.halstead.operators.total, 5);
-            });
+                test('aggregate has correct Halstead total operators', function () {
+                    assert.strictEqual(report.aggregate.halstead.operators.total, 5);
+                });
 
-            test('aggregate has correct Halstead distinct operators', function () {
-                assert.strictEqual(report.aggregate.halstead.operators.distinct, 4);
-            });
+                test('aggregate has correct Halstead distinct operators', function () {
+                    assert.strictEqual(report.aggregate.halstead.operators.distinct, 4);
+                });
 
-            test('aggregate has correct Halstead total operands', function () {
-                assert.strictEqual(report.aggregate.halstead.operands.total, 8);
-            });
+                test('aggregate has correct Halstead total operands', function () {
+                    assert.strictEqual(report.aggregate.halstead.operands.total, 8);
+                });
 
-            test('aggregate has correct Halstead distinct operands', function () {
-                assert.strictEqual(report.aggregate.halstead.operands.distinct, 7);
-            });
+                test('aggregate has correct Halstead distinct operands', function () {
+                    assert.strictEqual(report.aggregate.halstead.operands.distinct, 7);
+                });
 
-            test('aggregate has correct Halstead length', function () {
-                assert.strictEqual(report.aggregate.halstead.length, 13);
-            });
+                test('aggregate has correct Halstead length', function () {
+                    assert.strictEqual(report.aggregate.halstead.length, 13);
+                });
 
-            test('aggregate has correct Halstead vocabulary', function () {
-                assert.strictEqual(report.aggregate.halstead.vocabulary, 11);
-            });
+                test('aggregate has correct Halstead vocabulary', function () {
+                    assert.strictEqual(report.aggregate.halstead.vocabulary, 11);
+                });
 
-            test('aggregate has correct Halstead difficulty', function () {
-                assert.strictEqual(Math.round(report.aggregate.halstead.difficulty), 2);
+                test('aggregate has correct Halstead difficulty', function () {
+                    assert.strictEqual(Math.round(report.aggregate.halstead.difficulty), 2);
+                });
             });
-        });
 
-        suite('for...in loop containing condition:', function () {
-            var report;
+            suite('for...in loop containing condition:', function () {
+                var report;
 
-            setup(function () {
-                report = escomplex.analyse(espree.parse('var property, object = { foo: "bar", baz: "qux" }; for (property in object) { if (object.hasOwnProperty(property)) { "wibble"; } }', { loc: true }), mozWalker);
-            });
+                setup(function () {
+                    report = escomplex.analyse(parser.parse('var property, object = { foo: "bar", baz: "qux" }; for (property in object) { if (object.hasOwnProperty(property)) { "wibble"; } }', options), mozWalker);
+                });
 
-            teardown(function () {
-                report = undefined;
-            });
+                teardown(function () {
+                    report = undefined;
+                });
 
-            test('aggregate has correct cyclomatic complexity', function () {
-                assert.strictEqual(report.aggregate.cyclomatic, 2);
-            });
+                test('aggregate has correct cyclomatic complexity', function () {
+                    assert.strictEqual(report.aggregate.cyclomatic, 2);
+                });
 
-            test('aggregate has correct Halstead total operators', function () {
-                assert.strictEqual(report.aggregate.halstead.operators.total, 9);
-            });
+                test('aggregate has correct Halstead total operators', function () {
+                    assert.strictEqual(report.aggregate.halstead.operators.total, 9);
+                });
 
-            test('aggregate has correct Halstead distinct operators', function () {
-                assert.strictEqual(report.aggregate.halstead.operators.distinct, 8);
-            });
+                test('aggregate has correct Halstead distinct operators', function () {
+                    assert.strictEqual(report.aggregate.halstead.operators.distinct, 8);
+                });
 
-            test('aggregate has correct Halstead total operands', function () {
-                assert.strictEqual(report.aggregate.halstead.operands.total, 13);
-            });
+                test('aggregate has correct Halstead total operands', function () {
+                    assert.strictEqual(report.aggregate.halstead.operands.total, 13);
+                });
 
-            test('aggregate has correct Halstead distinct operands', function () {
-                assert.strictEqual(report.aggregate.halstead.operands.distinct, 9);
+                test('aggregate has correct Halstead distinct operands', function () {
+                    assert.strictEqual(report.aggregate.halstead.operands.distinct, 9);
+                });
             });
-        });
 
-        suite('while loop:', function () {
-            var report;
+            suite('while loop:', function () {
+                var report;
 
-            setup(function () {
-                report = escomplex.analyse(espree.parse('while (true) { "foo"; }', { loc: true }), mozWalker);
-            });
+                setup(function () {
+                    report = escomplex.analyse(parser.parse('while (true) { "foo"; }', options), mozWalker);
+                });
 
-            teardown(function () {
-                report = undefined;
-            });
+                teardown(function () {
+                    report = undefined;
+                });
 
-            test('aggregate has correct logical lines of code', function () {
-                assert.strictEqual(report.aggregate.sloc.logical, 2);
-            });
+                test('aggregate has correct logical lines of code', function () {
+                    assert.strictEqual(report.aggregate.sloc.logical, 2);
+                });
 
-            test('aggregate has correct cyclomatic complexity', function () {
-                assert.strictEqual(report.aggregate.cyclomatic, 2);
-            });
+                test('aggregate has correct cyclomatic complexity', function () {
+                    assert.strictEqual(report.aggregate.cyclomatic, 2);
+                });
 
-            test('functions is empty', function () {
-                assert.lengthOf(report.functions, 0);
-            });
+                test('functions is empty', function () {
+                    assert.lengthOf(report.functions, 0);
+                });
 
-            test('aggregate has correct Halstead total operators', function () {
-                assert.strictEqual(report.aggregate.halstead.operators.total, 1);
-            });
+                test('aggregate has correct Halstead total operators', function () {
+                    assert.strictEqual(report.aggregate.halstead.operators.total, 1);
+                });
 
-            test('aggregate has correct Halstead distinct operators', function () {
-                assert.strictEqual(report.aggregate.halstead.operators.distinct, 1);
-            });
+                test('aggregate has correct Halstead distinct operators', function () {
+                    assert.strictEqual(report.aggregate.halstead.operators.distinct, 1);
+                });
 
-            test('aggregate has correct Halstead total operands', function () {
-                assert.strictEqual(report.aggregate.halstead.operands.total, 2);
-            });
+                test('aggregate has correct Halstead total operands', function () {
+                    assert.strictEqual(report.aggregate.halstead.operands.total, 2);
+                });
 
-            test('aggregate has correct Halstead distinct operands', function () {
-                assert.strictEqual(report.aggregate.halstead.operands.distinct, 2);
+                test('aggregate has correct Halstead distinct operands', function () {
+                    assert.strictEqual(report.aggregate.halstead.operands.distinct, 2);
+                });
             });
-        });
 
-        suite('while loop containing condition:', function () {
-            var report;
+            suite('while loop containing condition:', function () {
+                var report;
 
-            setup(function () {
-                report = escomplex.analyse(espree.parse('while (true) { if (true) { "foo"; } }', { loc: true }), mozWalker);
-            });
+                setup(function () {
+                    report = escomplex.analyse(parser.parse('while (true) { if (true) { "foo"; } }', options), mozWalker);
+                });
 
-            teardown(function () {
-                report = undefined;
-            });
+                teardown(function () {
+                    report = undefined;
+                });
 
-            test('aggregate has correct cyclomatic complexity', function () {
-                assert.strictEqual(report.aggregate.cyclomatic, 3);
-            });
+                test('aggregate has correct cyclomatic complexity', function () {
+                    assert.strictEqual(report.aggregate.cyclomatic, 3);
+                });
 
-            test('aggregate has correct Halstead total operators', function () {
-                assert.strictEqual(report.aggregate.halstead.operators.total, 2);
-            });
+                test('aggregate has correct Halstead total operators', function () {
+                    assert.strictEqual(report.aggregate.halstead.operators.total, 2);
+                });
 
-            test('aggregate has correct Halstead distinct operators', function () {
-                assert.strictEqual(report.aggregate.halstead.operators.distinct, 2);
-            });
+                test('aggregate has correct Halstead distinct operators', function () {
+                    assert.strictEqual(report.aggregate.halstead.operators.distinct, 2);
+                });
 
-            test('aggregate has correct Halstead total operands', function () {
-                assert.strictEqual(report.aggregate.halstead.operands.total, 3);
-            });
+                test('aggregate has correct Halstead total operands', function () {
+                    assert.strictEqual(report.aggregate.halstead.operands.total, 3);
+                });
 
-            test('aggregate has correct Halstead distinct operands', function () {
-                assert.strictEqual(report.aggregate.halstead.operands.distinct, 2);
+                test('aggregate has correct Halstead distinct operands', function () {
+                    assert.strictEqual(report.aggregate.halstead.operands.distinct, 2);
+                });
             });
-        });
 
-        suite('do...while loop:', function () {
-            var report;
+            suite('do...while loop:', function () {
+                var report;
 
-            setup(function () {
-                report = escomplex.analyse(espree.parse('do { "foo"; } while (true)', { loc: true }), mozWalker);
-            });
+                setup(function () {
+                    report = escomplex.analyse(parser.parse('do { "foo"; } while (true)', options), mozWalker);
+                });
 
-            teardown(function () {
-                report = undefined;
-            });
+                teardown(function () {
+                    report = undefined;
+                });
 
-            test('aggregate has correct logical lines of code', function () {
-                assert.strictEqual(report.aggregate.sloc.logical, 3);
-            });
+                test('aggregate has correct logical lines of code', function () {
+                    assert.strictEqual(report.aggregate.sloc.logical, 3);
+                });
 
-            test('aggregate has correct cyclomatic complexity', function () {
-                assert.strictEqual(report.aggregate.cyclomatic, 2);
-            });
+                test('aggregate has correct cyclomatic complexity', function () {
+                    assert.strictEqual(report.aggregate.cyclomatic, 2);
+                });
 
-            test('functions is empty', function () {
-                assert.lengthOf(report.functions, 0);
-            });
+                test('functions is empty', function () {
+                    assert.lengthOf(report.functions, 0);
+                });
 
-            test('aggregate has correct Halstead total operators', function () {
-                assert.strictEqual(report.aggregate.halstead.operators.total, 1);
-            });
+                test('aggregate has correct Halstead total operators', function () {
+                    assert.strictEqual(report.aggregate.halstead.operators.total, 1);
+                });
 
-            test('aggregate has correct Halstead distinct operators', function () {
-                assert.strictEqual(report.aggregate.halstead.operators.distinct, 1);
-            });
+                test('aggregate has correct Halstead distinct operators', function () {
+                    assert.strictEqual(report.aggregate.halstead.operators.distinct, 1);
+                });
 
-            test('aggregate has correct Halstead total operands', function () {
-                assert.strictEqual(report.aggregate.halstead.operands.total, 2);
-            });
+                test('aggregate has correct Halstead total operands', function () {
+                    assert.strictEqual(report.aggregate.halstead.operands.total, 2);
+                });
 
-            test('aggregate has correct Halstead distinct operands', function () {
-                assert.strictEqual(report.aggregate.halstead.operands.distinct, 2);
+                test('aggregate has correct Halstead distinct operands', function () {
+                    assert.strictEqual(report.aggregate.halstead.operands.distinct, 2);
+                });
             });
-        });
 
-        suite('do...while loop containing condition:', function () {
-            var report;
+            suite('do...while loop containing condition:', function () {
+                var report;
 
-            setup(function () {
-                report = escomplex.analyse(espree.parse('do { if (true) { "foo"; } } while (true)', { loc: true }), mozWalker);
-            });
+                setup(function () {
+                    report = escomplex.analyse(parser.parse('do { if (true) { "foo"; } } while (true)', options), mozWalker);
+                });
 
-            teardown(function () {
-                report = undefined;
-            });
+                teardown(function () {
+                    report = undefined;
+                });
 
-            test('aggregate has correct cyclomatic complexity', function () {
-                assert.strictEqual(report.aggregate.cyclomatic, 3);
-            });
+                test('aggregate has correct cyclomatic complexity', function () {
+                    assert.strictEqual(report.aggregate.cyclomatic, 3);
+                });
 
-            test('aggregate has correct Halstead total operators', function () {
-                assert.strictEqual(report.aggregate.halstead.operators.total, 2);
-            });
+                test('aggregate has correct Halstead total operators', function () {
+                    assert.strictEqual(report.aggregate.halstead.operators.total, 2);
+                });
 
-            test('aggregate has correct Halstead distinct operators', function () {
-                assert.strictEqual(report.aggregate.halstead.operators.distinct, 2);
-            });
+                test('aggregate has correct Halstead distinct operators', function () {
+                    assert.strictEqual(report.aggregate.halstead.operators.distinct, 2);
+                });
 
-            test('aggregate has correct Halstead total operands', function () {
-                assert.strictEqual(report.aggregate.halstead.operands.total, 3);
-            });
+                test('aggregate has correct Halstead total operands', function () {
+                    assert.strictEqual(report.aggregate.halstead.operands.total, 3);
+                });
 
-            test('aggregate has correct Halstead distinct operands', function () {
-                assert.strictEqual(report.aggregate.halstead.operands.distinct, 2);
+                test('aggregate has correct Halstead distinct operands', function () {
+                    assert.strictEqual(report.aggregate.halstead.operands.distinct, 2);
+                });
             });
-        });
 
-        suite('try...catch:', function () {
-            var report;
+            suite('try...catch:', function () {
+                var report;
 
-            setup(function () {
-                var ast = espree.parse('try { "foo"; } catch (e) { e.message; }', { loc: true });
-                report = escomplex.analyse(ast, mozWalker);
-            });
+                setup(function () {
+                    var ast = parser.parse('try { "foo"; } catch (e) { e.message; }', options);
+                    report = escomplex.analyse(ast, mozWalker);
+                });
 
-            teardown(function () {
-                report = undefined;
-            });
+                teardown(function () {
+                    report = undefined;
+                });
 
-            test('aggregate has correct logical lines of code', function () {
-                assert.strictEqual(report.aggregate.sloc.logical, 4);
-            });
+                test('aggregate has correct logical lines of code', function () {
+                    assert.strictEqual(report.aggregate.sloc.logical, 4);
+                });
 
-            test('aggregate has correct cyclomatic complexity', function () {
-                assert.strictEqual(report.aggregate.cyclomatic, 1);
-            });
+                test('aggregate has correct cyclomatic complexity', function () {
+                    assert.strictEqual(report.aggregate.cyclomatic, 1);
+                });
 
-            test('functions is empty', function () {
-                assert.lengthOf(report.functions, 0);
-            });
+                test('functions is empty', function () {
+                    assert.lengthOf(report.functions, 0);
+                });
 
-            test('aggregate has correct Halstead total operators', function () {
-                assert.strictEqual(report.aggregate.halstead.operators.total, 2);
-            });
+                test('aggregate has correct Halstead total operators', function () {
+                    assert.strictEqual(report.aggregate.halstead.operators.total, 2);
+                });
 
-            test('aggregate has correct Halstead distinct operators', function () {
-                assert.strictEqual(report.aggregate.halstead.operators.distinct, 2);
-            });
+                test('aggregate has correct Halstead distinct operators', function () {
+                    assert.strictEqual(report.aggregate.halstead.operators.distinct, 2);
+                });
 
-            test('aggregate has correct Halstead total operands', function () {
-                assert.strictEqual(report.aggregate.halstead.operands.total, 4);
-            });
+                test('aggregate has correct Halstead total operands', function () {
+                    assert.strictEqual(report.aggregate.halstead.operands.total, 4);
+                });
 
-            test('aggregate has correct Halstead distinct operands', function () {
-                assert.strictEqual(report.aggregate.halstead.operands.distinct, 3);
+                test('aggregate has correct Halstead distinct operands', function () {
+                    assert.strictEqual(report.aggregate.halstead.operands.distinct, 3);
+                });
             });
-        });
 
-        suite('try containing condition', function () {
-            var report;
+            suite('try containing condition', function () {
+                var report;
 
-            setup(function () {
-                report = escomplex.analyse(espree.parse('try { if (true) { "foo"; } } catch (e) { "bar"; }', { loc: true }), mozWalker);
-            });
+                setup(function () {
+                    report = escomplex.analyse(parser.parse('try { if (true) { "foo"; } } catch (e) { "bar"; }', options), mozWalker);
+                });
 
-            teardown(function () {
-                report = undefined;
-            });
+                teardown(function () {
+                    report = undefined;
+                });
 
-            test('aggregate has correct cyclomatic complexity', function () {
-                assert.strictEqual(report.aggregate.cyclomatic, 2);
-            });
+                test('aggregate has correct cyclomatic complexity', function () {
+                    assert.strictEqual(report.aggregate.cyclomatic, 2);
+                });
 
-            test('aggregate has correct Halstead total operators', function () {
-                assert.strictEqual(report.aggregate.halstead.operators.total, 2);
-            });
+                test('aggregate has correct Halstead total operators', function () {
+                    assert.strictEqual(report.aggregate.halstead.operators.total, 2);
+                });
 
-            test('aggregate has correct Halstead distinct operators', function () {
-                assert.strictEqual(report.aggregate.halstead.operators.distinct, 2);
-            });
+                test('aggregate has correct Halstead distinct operators', function () {
+                    assert.strictEqual(report.aggregate.halstead.operators.distinct, 2);
+                });
 
-            test('aggregate has correct Halstead total operands', function () {
-                assert.strictEqual(report.aggregate.halstead.operands.total, 4);
-            });
+                test('aggregate has correct Halstead total operands', function () {
+                    assert.strictEqual(report.aggregate.halstead.operands.total, 4);
+                });
 
-            test('aggregate has correct Halstead distinct operands', function () {
-                assert.strictEqual(report.aggregate.halstead.operands.distinct, 4);
+                test('aggregate has correct Halstead distinct operands', function () {
+                    assert.strictEqual(report.aggregate.halstead.operands.distinct, 4);
+                });
             });
-        });
 
-        suite('catch containing condition', function () {
-            var report;
+            suite('catch containing condition', function () {
+                var report;
 
-            setup(function () {
-                report = escomplex.analyse(espree.parse('try { "foo"; } catch (e) { if (true) { "bar"; } }', { loc: true }), mozWalker);
-            });
+                setup(function () {
+                    report = escomplex.analyse(parser.parse('try { "foo"; } catch (e) { if (true) { "bar"; } }', options), mozWalker);
+                });
 
-            teardown(function () {
-                report = undefined;
-            });
+                teardown(function () {
+                    report = undefined;
+                });
 
-            test('aggregate has correct cyclomatic complexity', function () {
-                assert.strictEqual(report.aggregate.cyclomatic, 2);
-            });
+                test('aggregate has correct cyclomatic complexity', function () {
+                    assert.strictEqual(report.aggregate.cyclomatic, 2);
+                });
 
-            test('aggregate has correct Halstead total operators', function () {
-                assert.strictEqual(report.aggregate.halstead.operators.total, 2);
-            });
+                test('aggregate has correct Halstead total operators', function () {
+                    assert.strictEqual(report.aggregate.halstead.operators.total, 2);
+                });
 
-            test('aggregate has correct Halstead distinct operators', function () {
-                assert.strictEqual(report.aggregate.halstead.operators.distinct, 2);
-            });
+                test('aggregate has correct Halstead distinct operators', function () {
+                    assert.strictEqual(report.aggregate.halstead.operators.distinct, 2);
+                });
 
-            test('aggregate has correct Halstead total operands', function () {
-                assert.strictEqual(report.aggregate.halstead.operands.total, 4);
-            });
+                test('aggregate has correct Halstead total operands', function () {
+                    assert.strictEqual(report.aggregate.halstead.operands.total, 4);
+                });
 
-            test('aggregate has correct Halstead distinct operands', function () {
-                assert.strictEqual(report.aggregate.halstead.operands.distinct, 4);
+                test('aggregate has correct Halstead distinct operands', function () {
+                    assert.strictEqual(report.aggregate.halstead.operands.distinct, 4);
+                });
             });
-        });
 
-        suite('function declaration:', function () {
-            var report;
+            suite('function declaration:', function () {
+                var report;
 
-            setup(function () {
-                report = escomplex.analyse(espree.parse('function foo () { "bar"; }', { loc: true }), mozWalker);
-            });
+                setup(function () {
+                    report = escomplex.analyse(parser.parse('function foo () { "bar"; }', options), mozWalker);
+                });
 
-            teardown(function () {
-                report = undefined;
-            });
+                teardown(function () {
+                    report = undefined;
+                });
 
-            test('aggregate has correct logical lines of code', function () {
-                assert.strictEqual(report.aggregate.sloc.logical, 2);
-            });
+                test('aggregate has correct logical lines of code', function () {
+                    assert.strictEqual(report.aggregate.sloc.logical, 2);
+                });
 
-            test('aggregate has correct cyclomatic complexity', function () {
-                assert.strictEqual(report.aggregate.cyclomatic, 1);
-            });
+                test('aggregate has correct cyclomatic complexity', function () {
+                    assert.strictEqual(report.aggregate.cyclomatic, 1);
+                });
 
-            test('functions has correct length', function () {
-                assert.lengthOf(report.functions, 1);
-            });
+                test('functions has correct length', function () {
+                    assert.lengthOf(report.functions, 1);
+                });
 
-            test('function has correct name', function () {
-                assert.strictEqual(report.functions[0].name, 'foo');
-            });
+                test('function has correct name', function () {
+                    assert.strictEqual(report.functions[0].name, 'foo');
+                });
 
-            test('function has correct physical lines of code', function () {
-                assert.strictEqual(report.functions[0].sloc.physical, 1);
-            });
+                test('function has correct physical lines of code', function () {
+                    assert.strictEqual(report.functions[0].sloc.physical, 1);
+                });
 
-            test('function has correct logical lines of code', function () {
-                assert.strictEqual(report.functions[0].sloc.logical, 1);
-            });
+                test('function has correct logical lines of code', function () {
+                    assert.strictEqual(report.functions[0].sloc.logical, 1);
+                });
 
-            test('function has correct cyclomatic complexity', function () {
-                assert.strictEqual(report.functions[0].cyclomatic, 1);
-            });
+                test('function has correct cyclomatic complexity', function () {
+                    assert.strictEqual(report.functions[0].cyclomatic, 1);
+                });
 
-            test('function has correct parameter count', function () {
-                assert.strictEqual(report.functions[0].params, 0);
-            });
+                test('function has correct parameter count', function () {
+                    assert.strictEqual(report.functions[0].params, 0);
+                });
 
-            test('aggregate has correct Halstead total operators', function () {
-                assert.strictEqual(report.aggregate.halstead.operators.total, 1);
-            });
+                test('aggregate has correct Halstead total operators', function () {
+                    assert.strictEqual(report.aggregate.halstead.operators.total, 1);
+                });
 
-            test('aggregate has correct Halstead distinct operators', function () {
-                assert.strictEqual(report.aggregate.halstead.operators.distinct, 1);
-            });
+                test('aggregate has correct Halstead distinct operators', function () {
+                    assert.strictEqual(report.aggregate.halstead.operators.distinct, 1);
+                });
 
-            test('aggregate has correct Halstead total operands', function () {
-                assert.strictEqual(report.aggregate.halstead.operands.total, 2);
-            });
+                test('aggregate has correct Halstead total operands', function () {
+                    assert.strictEqual(report.aggregate.halstead.operands.total, 2);
+                });
 
-            test('aggregate has correct Halstead distinct operands', function () {
-                assert.strictEqual(report.aggregate.halstead.operands.distinct, 2);
-            });
+                test('aggregate has correct Halstead distinct operands', function () {
+                    assert.strictEqual(report.aggregate.halstead.operands.distinct, 2);
+                });
 
-            test('aggregate has correct Halstead length', function () {
-                assert.strictEqual(report.aggregate.halstead.length, 3);
-            });
+                test('aggregate has correct Halstead length', function () {
+                    assert.strictEqual(report.aggregate.halstead.length, 3);
+                });
 
-            test('aggregate has correct Halstead vocabulary', function () {
-                assert.strictEqual(report.aggregate.halstead.vocabulary, 3);
-            });
+                test('aggregate has correct Halstead vocabulary', function () {
+                    assert.strictEqual(report.aggregate.halstead.vocabulary, 3);
+                });
 
-            test('aggregate has correct Halstead difficulty', function () {
-                assert.strictEqual(report.aggregate.halstead.difficulty, 0.5);
-            });
+                test('aggregate has correct Halstead difficulty', function () {
+                    assert.strictEqual(report.aggregate.halstead.difficulty, 0.5);
+                });
 
-            test('function has correct Halstead length', function () {
-                assert.strictEqual(report.functions[0].halstead.length, 1);
-            });
+                test('function has correct Halstead length', function () {
+                    assert.strictEqual(report.functions[0].halstead.length, 1);
+                });
 
-            test('function has correct Halstead vocabulary', function () {
-                assert.strictEqual(report.functions[0].halstead.vocabulary, 1);
-            });
+                test('function has correct Halstead vocabulary', function () {
+                    assert.strictEqual(report.functions[0].halstead.vocabulary, 1);
+                });
 
-            test('function has correct Halstead difficulty', function () {
-                assert.strictEqual(report.functions[0].halstead.difficulty, 0);
-            });
+                test('function has correct Halstead difficulty', function () {
+                    assert.strictEqual(report.functions[0].halstead.difficulty, 0);
+                });
 
-            test('function has correct Halstead volume', function () {
-                assert.strictEqual(report.functions[0].halstead.volume, 0);
-            });
+                test('function has correct Halstead volume', function () {
+                    assert.strictEqual(report.functions[0].halstead.volume, 0);
+                });
 
-            test('function has correct Halstead effort', function () {
-                assert.strictEqual(report.functions[0].halstead.effort, 0);
-            });
+                test('function has correct Halstead effort', function () {
+                    assert.strictEqual(report.functions[0].halstead.effort, 0);
+                });
 
-            test('function has correct Halstead bugs', function () {
-                assert.strictEqual(report.functions[0].halstead.bugs, 0);
-            });
+                test('function has correct Halstead bugs', function () {
+                    assert.strictEqual(report.functions[0].halstead.bugs, 0);
+                });
 
-            test('function has correct Halstead time', function () {
-                assert.strictEqual(report.functions[0].halstead.time, 0);
-            });
+                test('function has correct Halstead time', function () {
+                    assert.strictEqual(report.functions[0].halstead.time, 0);
+                });
 
-            test('maintainability index is correct', function () {
-                assert.strictEqual(report.maintainability, 171);
-            });
+                test('maintainability index is correct', function () {
+                    assert.strictEqual(report.maintainability, 171);
+                });
 
-            test('aggregate has correct parameter count', function () {
-                assert.strictEqual(report.aggregate.params, 0);
+                test('aggregate has correct parameter count', function () {
+                    assert.strictEqual(report.aggregate.params, 0);
+                });
             });
-        });
 
-        suite('nested function declaration:', function () {
-            var report;
+            suite('nested function declaration:', function () {
+                var report;
 
-            setup(function () {
-                report = escomplex.analyse(espree.parse('function foo () { bar(); function bar () { "baz"; } }', { loc: true }), mozWalker);
-            });
+                setup(function () {
+                    report = escomplex.analyse(parser.parse('function foo () { bar(); function bar () { "baz"; } }', options), mozWalker);
+                });
 
-            teardown(function () {
-                report = undefined;
-            });
+                teardown(function () {
+                    report = undefined;
+                });
 
-            test('aggregate has correct logical lines of code', function () {
-                assert.strictEqual(report.aggregate.sloc.logical, 4);
-            });
+                test('aggregate has correct logical lines of code', function () {
+                    assert.strictEqual(report.aggregate.sloc.logical, 4);
+                });
 
-            test('functions has correct length', function () {
-                assert.lengthOf(report.functions, 2);
-            });
+                test('functions has correct length', function () {
+                    assert.lengthOf(report.functions, 2);
+                });
 
-            test('first function has correct logical lines of code', function () {
-                assert.strictEqual(report.functions[0].sloc.logical, 2);
-            });
+                test('first function has correct logical lines of code', function () {
+                    assert.strictEqual(report.functions[0].sloc.logical, 2);
+                });
 
-            test('second function has correct logical lines of code', function () {
-                assert.strictEqual(report.functions[1].sloc.logical, 1);
-            });
+                test('second function has correct logical lines of code', function () {
+                    assert.strictEqual(report.functions[1].sloc.logical, 1);
+                });
 
-            test('first function has correct name', function () {
-                assert.strictEqual(report.functions[0].name, 'foo');
-            });
+                test('first function has correct name', function () {
+                    assert.strictEqual(report.functions[0].name, 'foo');
+                });
 
-            test('second function has correct name', function () {
-                assert.strictEqual(report.functions[1].name, 'bar');
-            });
+                test('second function has correct name', function () {
+                    assert.strictEqual(report.functions[1].name, 'bar');
+                });
 
-            test('aggregate has correct Halstead total operators', function () {
-                assert.strictEqual(report.aggregate.halstead.operators.total, 3);
-            });
+                test('aggregate has correct Halstead total operators', function () {
+                    assert.strictEqual(report.aggregate.halstead.operators.total, 3);
+                });
 
-            test('aggregate has correct Halstead distinct operators', function () {
-                assert.strictEqual(report.aggregate.halstead.operators.distinct, 2);
-            });
+                test('aggregate has correct Halstead distinct operators', function () {
+                    assert.strictEqual(report.aggregate.halstead.operators.distinct, 2);
+                });
 
-            test('aggregate has correct Halstead total operands', function () {
-                assert.strictEqual(report.aggregate.halstead.operands.total, 4);
-            });
+                test('aggregate has correct Halstead total operands', function () {
+                    assert.strictEqual(report.aggregate.halstead.operands.total, 4);
+                });
 
-            test('aggregate has correct Halstead distinct operands', function () {
-                assert.strictEqual(report.aggregate.halstead.operands.distinct, 3);
+                test('aggregate has correct Halstead distinct operands', function () {
+                    assert.strictEqual(report.aggregate.halstead.operands.distinct, 3);
+                });
             });
-        });
 
-        suite('function declaration containing condition:', function () {
-            var report;
+            suite('function declaration containing condition:', function () {
+                var report;
 
-            setup(function () {
-                report = escomplex.analyse(espree.parse('function foo () { if (true) { "bar"; } }', { loc: true }), mozWalker);
-            });
+                setup(function () {
+                    report = escomplex.analyse(parser.parse('function foo () { if (true) { "bar"; } }', options), mozWalker);
+                });
 
-            teardown(function () {
-                report = undefined;
-            });
+                teardown(function () {
+                    report = undefined;
+                });
 
-            test('aggregate has correct cyclomatic complexity', function () {
-                assert.strictEqual(report.aggregate.cyclomatic, 2);
-            });
+                test('aggregate has correct cyclomatic complexity', function () {
+                    assert.strictEqual(report.aggregate.cyclomatic, 2);
+                });
 
-            test('function has correct cyclomatic complexity', function () {
-                assert.strictEqual(report.functions[0].cyclomatic, 2);
-            });
+                test('function has correct cyclomatic complexity', function () {
+                    assert.strictEqual(report.functions[0].cyclomatic, 2);
+                });
 
-            test('function has correct cyclomatic complexity', function () {
-                assert.strictEqual(report.functions[0].cyclomaticDensity, 100);
-            });
+                test('function has correct cyclomatic complexity', function () {
+                    assert.strictEqual(report.functions[0].cyclomaticDensity, 100);
+                });
 
-            test('aggregate has correct Halstead total operators', function () {
-                assert.strictEqual(report.aggregate.halstead.operators.total, 2);
-            });
+                test('aggregate has correct Halstead total operators', function () {
+                    assert.strictEqual(report.aggregate.halstead.operators.total, 2);
+                });
 
-            test('aggregate has correct Halstead distinct operators', function () {
-                assert.strictEqual(report.aggregate.halstead.operators.distinct, 2);
-            });
+                test('aggregate has correct Halstead distinct operators', function () {
+                    assert.strictEqual(report.aggregate.halstead.operators.distinct, 2);
+                });
 
-            test('aggregate has correct Halstead total operands', function () {
-                assert.strictEqual(report.aggregate.halstead.operands.total, 3);
-            });
+                test('aggregate has correct Halstead total operands', function () {
+                    assert.strictEqual(report.aggregate.halstead.operands.total, 3);
+                });
 
-            test('aggregate has correct Halstead distinct operands', function () {
-                assert.strictEqual(report.aggregate.halstead.operands.distinct, 3);
+                test('aggregate has correct Halstead distinct operands', function () {
+                    assert.strictEqual(report.aggregate.halstead.operands.distinct, 3);
+                });
             });
-        });
 
-        suite('assignment expression', function () {
-            var report;
+            suite('assignment expression', function () {
+                var report;
 
-            setup(function () {
-                report = escomplex.analyse(espree.parse('var foo = "bar";', { loc: true }), mozWalker);
-            });
+                setup(function () {
+                    report = escomplex.analyse(parser.parse('var foo = "bar";', options), mozWalker);
+                });
 
-            teardown(function () {
-                report = undefined;
-            });
+                teardown(function () {
+                    report = undefined;
+                });
 
-            test('aggregate has correct logical lines of code', function () {
-                assert.strictEqual(report.aggregate.sloc.logical, 1);
-            });
+                test('aggregate has correct logical lines of code', function () {
+                    assert.strictEqual(report.aggregate.sloc.logical, 1);
+                });
 
-            test('aggregate has correct cyclomatic complexity', function () {
-                assert.strictEqual(report.aggregate.cyclomatic, 1);
-            });
+                test('aggregate has correct cyclomatic complexity', function () {
+                    assert.strictEqual(report.aggregate.cyclomatic, 1);
+                });
 
-            test('functions is empty', function () {
-                assert.lengthOf(report.functions, 0);
-            });
+                test('functions is empty', function () {
+                    assert.lengthOf(report.functions, 0);
+                });
 
-            test('aggregate has correct Halstead total operators', function () {
-                assert.strictEqual(report.aggregate.halstead.operators.total, 2);
-            });
+                test('aggregate has correct Halstead total operators', function () {
+                    assert.strictEqual(report.aggregate.halstead.operators.total, 2);
+                });
 
-            test('aggregate has correct Halstead distinct operators', function () {
-                assert.strictEqual(report.aggregate.halstead.operators.distinct, 2);
-            });
+                test('aggregate has correct Halstead distinct operators', function () {
+                    assert.strictEqual(report.aggregate.halstead.operators.distinct, 2);
+                });
 
-            test('aggregate has correct Halstead total operands', function () {
-                assert.strictEqual(report.aggregate.halstead.operands.total, 2);
-            });
+                test('aggregate has correct Halstead total operands', function () {
+                    assert.strictEqual(report.aggregate.halstead.operands.total, 2);
+                });
 
-            test('aggregate has correct Halstead distinct operands', function () {
-                assert.strictEqual(report.aggregate.halstead.operands.distinct, 2);
+                test('aggregate has correct Halstead distinct operands', function () {
+                    assert.strictEqual(report.aggregate.halstead.operands.distinct, 2);
+                });
             });
-        });
 
-        suite('ternary condtional expression assigned to variable:', function () {
-            var report;
+            suite('ternary condtional expression assigned to variable:', function () {
+                var report;
 
-            setup(function () {
-                report = escomplex.analyse(espree.parse('var foo = true ? "bar" : "baz";', { loc: true }), mozWalker);
-            });
+                setup(function () {
+                    report = escomplex.analyse(parser.parse('var foo = true ? "bar" : "baz";', options), mozWalker);
+                });
 
-            teardown(function () {
-                report = undefined;
-            });
+                teardown(function () {
+                    report = undefined;
+                });
 
-            test('aggregate has correct logical lines of code', function () {
-                assert.strictEqual(report.aggregate.sloc.logical, 1);
-            });
+                test('aggregate has correct logical lines of code', function () {
+                    assert.strictEqual(report.aggregate.sloc.logical, 1);
+                });
 
-            test('aggregate has correct cyclomatic complexity', function () {
-                assert.strictEqual(report.aggregate.cyclomatic, 2);
-            });
+                test('aggregate has correct cyclomatic complexity', function () {
+                    assert.strictEqual(report.aggregate.cyclomatic, 2);
+                });
 
-            test('aggregate has correct Halstead total operators', function () {
-                assert.strictEqual(report.aggregate.halstead.operators.total, 3);
-            });
+                test('aggregate has correct Halstead total operators', function () {
+                    assert.strictEqual(report.aggregate.halstead.operators.total, 3);
+                });
 
-            test('aggregate has correct Halstead distinct operators', function () {
-                assert.strictEqual(report.aggregate.halstead.operators.distinct, 3);
-            });
+                test('aggregate has correct Halstead distinct operators', function () {
+                    assert.strictEqual(report.aggregate.halstead.operators.distinct, 3);
+                });
 
-            test('aggregate has correct Halstead total operands', function () {
-                assert.strictEqual(report.aggregate.halstead.operands.total, 4);
-            });
+                test('aggregate has correct Halstead total operands', function () {
+                    assert.strictEqual(report.aggregate.halstead.operands.total, 4);
+                });
 
-            test('aggregate has correct Halstead distinct operands', function () {
-                assert.strictEqual(report.aggregate.halstead.operands.distinct, 4);
+                test('aggregate has correct Halstead distinct operands', function () {
+                    assert.strictEqual(report.aggregate.halstead.operands.distinct, 4);
+                });
             });
-        });
 
-        suite('nested ternary condtional expression:', function () {
-            var report;
+            suite('nested ternary condtional expression:', function () {
+                var report;
 
-            setup(function () {
-                report = escomplex.analyse(espree.parse('var foo = true ? "bar" : (false ? "baz" : "qux");', { loc: true }), mozWalker);
-            });
+                setup(function () {
+                    report = escomplex.analyse(parser.parse('var foo = true ? "bar" : (false ? "baz" : "qux");', options), mozWalker);
+                });
 
-            teardown(function () {
-                report = undefined;
-            });
+                teardown(function () {
+                    report = undefined;
+                });
 
-            test('aggregate has correct logical lines of code', function () {
-                assert.strictEqual(report.aggregate.sloc.logical, 1);
-            });
+                test('aggregate has correct logical lines of code', function () {
+                    assert.strictEqual(report.aggregate.sloc.logical, 1);
+                });
 
-            test('aggregate has correct cyclomatic complexity', function () {
-                assert.strictEqual(report.aggregate.cyclomatic, 3);
-            });
+                test('aggregate has correct cyclomatic complexity', function () {
+                    assert.strictEqual(report.aggregate.cyclomatic, 3);
+                });
 
-            test('aggregate has correct Halstead total operators', function () {
-                assert.strictEqual(report.aggregate.halstead.operators.total, 4);
-            });
+                test('aggregate has correct Halstead total operators', function () {
+                    assert.strictEqual(report.aggregate.halstead.operators.total, 4);
+                });
 
-            test('aggregate has correct Halstead distinct operators', function () {
-                assert.strictEqual(report.aggregate.halstead.operators.distinct, 3);
-            });
+                test('aggregate has correct Halstead distinct operators', function () {
+                    assert.strictEqual(report.aggregate.halstead.operators.distinct, 3);
+                });
 
-            test('aggregate has correct Halstead total operands', function () {
-                assert.strictEqual(report.aggregate.halstead.operands.total, 6);
-            });
+                test('aggregate has correct Halstead total operands', function () {
+                    assert.strictEqual(report.aggregate.halstead.operands.total, 6);
+                });
 
-            test('aggregate has correct Halstead distinct operands', function () {
-                assert.strictEqual(report.aggregate.halstead.operands.distinct, 6);
+                test('aggregate has correct Halstead distinct operands', function () {
+                    assert.strictEqual(report.aggregate.halstead.operands.distinct, 6);
+                });
             });
-        });
 
-        suite('logical or expression assigned to variable:', function () {
-            var report;
+            suite('logical or expression assigned to variable:', function () {
+                var report;
 
-            setup(function () {
-                report = escomplex.analyse(espree.parse('var foo = true || false;', { loc: true }), mozWalker);
-            });
+                setup(function () {
+                    report = escomplex.analyse(parser.parse('var foo = true || false;', options), mozWalker);
+                });
 
-            teardown(function () {
-                report = undefined;
-            });
+                teardown(function () {
+                    report = undefined;
+                });
 
-            test('aggregate has correct logical lines of code', function () {
-                assert.strictEqual(report.aggregate.sloc.logical, 1);
-            });
+                test('aggregate has correct logical lines of code', function () {
+                    assert.strictEqual(report.aggregate.sloc.logical, 1);
+                });
 
-            test('aggregate has correct cyclomatic complexity', function () {
-                assert.strictEqual(report.aggregate.cyclomatic, 2);
-            });
+                test('aggregate has correct cyclomatic complexity', function () {
+                    assert.strictEqual(report.aggregate.cyclomatic, 2);
+                });
 
-            test('aggregate has correct Halstead total operators', function () {
-                assert.strictEqual(report.aggregate.halstead.operators.total, 3);
-            });
+                test('aggregate has correct Halstead total operators', function () {
+                    assert.strictEqual(report.aggregate.halstead.operators.total, 3);
+                });
 
-            test('aggregate has correct Halstead distinct operators', function () {
-                assert.strictEqual(report.aggregate.halstead.operators.distinct, 3);
-            });
+                test('aggregate has correct Halstead distinct operators', function () {
+                    assert.strictEqual(report.aggregate.halstead.operators.distinct, 3);
+                });
 
-            test('aggregate has correct Halstead total operands', function () {
-                assert.strictEqual(report.aggregate.halstead.operands.total, 3);
-            });
+                test('aggregate has correct Halstead total operands', function () {
+                    assert.strictEqual(report.aggregate.halstead.operands.total, 3);
+                });
 
-            test('aggregate has correct Halstead distinct operands', function () {
-                assert.strictEqual(report.aggregate.halstead.operands.distinct, 3);
+                test('aggregate has correct Halstead distinct operands', function () {
+                    assert.strictEqual(report.aggregate.halstead.operands.distinct, 3);
+                });
             });
-        });
 
-        suite('anonymous function assigned to variable:', function () {
-            var report;
+            suite('anonymous function assigned to variable:', function () {
+                var report;
 
-            setup(function () {
-                report = escomplex.analyse(espree.parse('var foo = function () { "bar"; }', { loc: true }), mozWalker);
-            });
+                setup(function () {
+                    report = escomplex.analyse(parser.parse('var foo = function () { "bar"; }', options), mozWalker);
+                });
 
-            teardown(function () {
-                report = undefined;
-            });
+                teardown(function () {
+                    report = undefined;
+                });
 
-            test('aggregate has correct logical lines of code', function () {
-                assert.strictEqual(report.aggregate.sloc.logical, 2);
-            });
+                test('aggregate has correct logical lines of code', function () {
+                    assert.strictEqual(report.aggregate.sloc.logical, 2);
+                });
 
-            test('functions has correct length', function () {
-                assert.lengthOf(report.functions, 1);
-            });
+                test('functions has correct length', function () {
+                    assert.lengthOf(report.functions, 1);
+                });
 
-            test('function has correct name', function () {
-                assert.strictEqual(report.functions[0].name, 'foo');
-            });
+                test('function has correct name', function () {
+                    assert.strictEqual(report.functions[0].name, 'foo');
+                });
 
-            test('aggregate has correct Halstead total operators', function () {
-                assert.strictEqual(report.aggregate.halstead.operators.total, 3);
-            });
+                test('aggregate has correct Halstead total operators', function () {
+                    assert.strictEqual(report.aggregate.halstead.operators.total, 3);
+                });
 
-            test('aggregate has correct Halstead distinct operators', function () {
-                assert.strictEqual(report.aggregate.halstead.operators.distinct, 3);
-            });
+                test('aggregate has correct Halstead distinct operators', function () {
+                    assert.strictEqual(report.aggregate.halstead.operators.distinct, 3);
+                });
 
-            test('aggregate has correct Halstead total operands', function () {
-                assert.strictEqual(report.aggregate.halstead.operands.total, 3);
-            });
+                test('aggregate has correct Halstead total operands', function () {
+                    assert.strictEqual(report.aggregate.halstead.operands.total, 3);
+                });
 
-            test('aggregate has correct Halstead distinct operands', function () {
-                assert.strictEqual(report.aggregate.halstead.operands.distinct, 3);
+                test('aggregate has correct Halstead distinct operands', function () {
+                    assert.strictEqual(report.aggregate.halstead.operands.distinct, 3);
+                });
             });
-        });
 
-        suite('named function assigned to variable:', function () {
-            var report;
+            suite('named function assigned to variable:', function () {
+                var report;
 
-            setup(function () {
-                report = escomplex.analyse(espree.parse('var foo = function bar () { "baz"; }', { loc: true }), mozWalker);
-            });
+                setup(function () {
+                    report = escomplex.analyse(parser.parse('var foo = function bar () { "baz"; }', options), mozWalker);
+                });
 
-            teardown(function () {
-                report = undefined;
-            });
+                teardown(function () {
+                    report = undefined;
+                });
 
-            test('aggregate has correct logical lines of code', function () {
-                assert.strictEqual(report.aggregate.sloc.logical, 2);
-            });
+                test('aggregate has correct logical lines of code', function () {
+                    assert.strictEqual(report.aggregate.sloc.logical, 2);
+                });
 
-            test('function has correct name', function () {
-                assert.strictEqual(report.functions[0].name, 'bar');
-            });
+                test('function has correct name', function () {
+                    assert.strictEqual(report.functions[0].name, 'bar');
+                });
 
-            test('aggregate has correct Halstead total operands', function () {
-                assert.strictEqual(report.aggregate.halstead.operands.total, 3);
-            });
+                test('aggregate has correct Halstead total operands', function () {
+                    assert.strictEqual(report.aggregate.halstead.operands.total, 3);
+                });
 
-            test('aggregate has correct Halstead distinct operands', function () {
-                assert.strictEqual(report.aggregate.halstead.operands.distinct, 3);
+                test('aggregate has correct Halstead distinct operands', function () {
+                    assert.strictEqual(report.aggregate.halstead.operands.distinct, 3);
+                });
             });
-        });
 
-        suite('ternary condtional expression returned from function:', function () {
-            var report;
+            suite('ternary condtional expression returned from function:', function () {
+                var report;
 
-            setup(function () {
-                report = escomplex.analyse(espree.parse('function foo () { return true ? "bar" : "baz"; }', { loc: true }), mozWalker);
-            });
+                setup(function () {
+                    report = escomplex.analyse(parser.parse('function foo () { return true ? "bar" : "baz"; }', options), mozWalker);
+                });
 
-            teardown(function () {
-                report = undefined;
-            });
+                teardown(function () {
+                    report = undefined;
+                });
 
-            test('aggregate has correct logical lines of code', function () {
-                assert.strictEqual(report.aggregate.sloc.logical, 2);
-            });
+                test('aggregate has correct logical lines of code', function () {
+                    assert.strictEqual(report.aggregate.sloc.logical, 2);
+                });
 
-            test('aggregate has correct cyclomatic complexity', function () {
-                assert.strictEqual(report.aggregate.cyclomatic, 2);
-            });
+                test('aggregate has correct cyclomatic complexity', function () {
+                    assert.strictEqual(report.aggregate.cyclomatic, 2);
+                });
 
-            test('function has correct cyclomatic complexity', function () {
-                assert.strictEqual(report.functions[0].cyclomatic, 2);
-            });
+                test('function has correct cyclomatic complexity', function () {
+                    assert.strictEqual(report.functions[0].cyclomatic, 2);
+                });
 
-            test('aggregate has correct Halstead total operators', function () {
-                assert.strictEqual(report.aggregate.halstead.operators.total, 3);
-            });
+                test('aggregate has correct Halstead total operators', function () {
+                    assert.strictEqual(report.aggregate.halstead.operators.total, 3);
+                });
 
-            test('aggregate has correct Halstead distinct operators', function () {
-                assert.strictEqual(report.aggregate.halstead.operators.distinct, 3);
-            });
+                test('aggregate has correct Halstead distinct operators', function () {
+                    assert.strictEqual(report.aggregate.halstead.operators.distinct, 3);
+                });
 
-            test('aggregate has correct Halstead total operands', function () {
-                assert.strictEqual(report.aggregate.halstead.operands.total, 4);
-            });
+                test('aggregate has correct Halstead total operands', function () {
+                    assert.strictEqual(report.aggregate.halstead.operands.total, 4);
+                });
 
-            test('aggregate has correct Halstead distinct operands', function () {
-                assert.strictEqual(report.aggregate.halstead.operands.distinct, 4);
+                test('aggregate has correct Halstead distinct operands', function () {
+                    assert.strictEqual(report.aggregate.halstead.operands.distinct, 4);
+                });
             });
-        });
 
-        suite('logical or expression returned from function:', function () {
-            var report;
+            suite('logical or expression returned from function:', function () {
+                var report;
 
-            setup(function () {
-                report = escomplex.analyse(espree.parse('function foo () { return true || false; }', { loc: true }), mozWalker);
-            });
+                setup(function () {
+                    report = escomplex.analyse(parser.parse('function foo () { return true || false; }', options), mozWalker);
+                });
 
-            teardown(function () {
-                report = undefined;
-            });
+                teardown(function () {
+                    report = undefined;
+                });
 
-            test('aggregate has correct logical lines of code', function () {
-                assert.strictEqual(report.aggregate.sloc.logical, 2);
-            });
+                test('aggregate has correct logical lines of code', function () {
+                    assert.strictEqual(report.aggregate.sloc.logical, 2);
+                });
 
-            test('aggregate has correct cyclomatic complexity', function () {
-                assert.strictEqual(report.aggregate.cyclomatic, 2);
-            });
+                test('aggregate has correct cyclomatic complexity', function () {
+                    assert.strictEqual(report.aggregate.cyclomatic, 2);
+                });
 
-            test('function has correct cyclomatic complexity', function () {
-                assert.strictEqual(report.functions[0].cyclomatic, 2);
-            });
+                test('function has correct cyclomatic complexity', function () {
+                    assert.strictEqual(report.functions[0].cyclomatic, 2);
+                });
 
-            test('aggregate has correct Halstead total operands', function () {
-                assert.strictEqual(report.aggregate.halstead.operands.total, 3);
-            });
+                test('aggregate has correct Halstead total operands', function () {
+                    assert.strictEqual(report.aggregate.halstead.operands.total, 3);
+                });
 
-            test('aggregate has correct Halstead distinct operands', function () {
-                assert.strictEqual(report.aggregate.halstead.operands.distinct, 3);
+                test('aggregate has correct Halstead distinct operands', function () {
+                    assert.strictEqual(report.aggregate.halstead.operands.distinct, 3);
+                });
             });
-        });
 
-        suite('anonymous function returned from function:', function () {
-            var report;
+            suite('anonymous function returned from function:', function () {
+                var report;
 
-            setup(function () {
-                report = escomplex.analyse(espree.parse('function foo () { return function () { "bar"; }; }', { loc: true }), mozWalker);
-            });
+                setup(function () {
+                    report = escomplex.analyse(parser.parse('function foo () { return function () { "bar"; }; }', options), mozWalker);
+                });
 
-            teardown(function () {
-                report = undefined;
-            });
+                teardown(function () {
+                    report = undefined;
+                });
 
-            test('aggregate has correct logical lines of code', function () {
-                assert.strictEqual(report.aggregate.sloc.logical, 3);
-            });
+                test('aggregate has correct logical lines of code', function () {
+                    assert.strictEqual(report.aggregate.sloc.logical, 3);
+                });
 
-            test('functions has correct length', function () {
-                assert.lengthOf(report.functions, 2);
-            });
+                test('functions has correct length', function () {
+                    assert.lengthOf(report.functions, 2);
+                });
 
-            test('first function has correct name', function () {
-                assert.strictEqual(report.functions[0].name, 'foo');
-            });
+                test('first function has correct name', function () {
+                    assert.strictEqual(report.functions[0].name, 'foo');
+                });
 
-            test('second function is anonymous', function () {
-                assert.strictEqual(report.functions[1].name, '<anonymous>');
-            });
+                test('second function is anonymous', function () {
+                    assert.strictEqual(report.functions[1].name, '<anonymous>');
+                });
 
-            test('aggregate has correct Halstead total operators', function () {
-                assert.strictEqual(report.aggregate.halstead.operators.total, 3);
-            });
+                test('aggregate has correct Halstead total operators', function () {
+                    assert.strictEqual(report.aggregate.halstead.operators.total, 3);
+                });
 
-            test('aggregate has correct Halstead distinct operators', function () {
-                assert.strictEqual(report.aggregate.halstead.operators.distinct, 2);
-            });
+                test('aggregate has correct Halstead distinct operators', function () {
+                    assert.strictEqual(report.aggregate.halstead.operators.distinct, 2);
+                });
 
-            test('aggregate has correct Halstead total operands', function () {
-                assert.strictEqual(report.aggregate.halstead.operands.total, 3);
-            });
+                test('aggregate has correct Halstead total operands', function () {
+                    assert.strictEqual(report.aggregate.halstead.operands.total, 3);
+                });
 
-            test('aggregate has correct Halstead distinct operands', function () {
-                assert.strictEqual(report.aggregate.halstead.operands.distinct, 3);
+                test('aggregate has correct Halstead distinct operands', function () {
+                    assert.strictEqual(report.aggregate.halstead.operands.distinct, 3);
+                });
             });
-        });
 
-        suite('named function returned from function:', function () {
-            var report;
+            suite('named function returned from function:', function () {
+                var report;
 
-            setup(function () {
-                report = escomplex.analyse(espree.parse('function foo () { return function bar () { "baz"; }; }', { loc: true }), mozWalker);
-            });
+                setup(function () {
+                    report = escomplex.analyse(parser.parse('function foo () { return function bar () { "baz"; }; }', options), mozWalker);
+                });
 
-            teardown(function () {
-                report = undefined;
-            });
+                teardown(function () {
+                    report = undefined;
+                });
 
-            test('second function has correct name', function () {
-                assert.strictEqual(report.functions[1].name, 'bar');
-            });
+                test('second function has correct name', function () {
+                    assert.strictEqual(report.functions[1].name, 'bar');
+                });
 
-            test('aggregate has correct Halstead total operands', function () {
-                assert.strictEqual(report.aggregate.halstead.operands.total, 3);
-            });
+                test('aggregate has correct Halstead total operands', function () {
+                    assert.strictEqual(report.aggregate.halstead.operands.total, 3);
+                });
 
-            test('aggregate has correct Halstead distinct operands', function () {
-                assert.strictEqual(report.aggregate.halstead.operands.distinct, 3);
+                test('aggregate has correct Halstead distinct operands', function () {
+                    assert.strictEqual(report.aggregate.halstead.operands.distinct, 3);
+                });
             });
-        });
 
-        suite('ternary condtional expression passed as argument:', function () {
-            var report;
+            suite('ternary condtional expression passed as argument:', function () {
+                var report;
 
-            setup(function () {
-                report = escomplex.analyse(espree.parse('parseInt("10", true ? 10 : 8);', { loc: true }), mozWalker);
-            });
+                setup(function () {
+                    report = escomplex.analyse(parser.parse('parseInt("10", true ? 10 : 8);', options), mozWalker);
+                });
 
-            teardown(function () {
-                report = undefined;
-            });
+                teardown(function () {
+                    report = undefined;
+                });
 
-            test('aggregate has correct cyclomatic complexity', function () {
-                assert.strictEqual(report.aggregate.cyclomatic, 2);
-            });
+                test('aggregate has correct cyclomatic complexity', function () {
+                    assert.strictEqual(report.aggregate.cyclomatic, 2);
+                });
 
-            test('aggregate has correct Halstead total operators', function () {
-                assert.strictEqual(report.aggregate.halstead.operators.total, 2);
-            });
+                test('aggregate has correct Halstead total operators', function () {
+                    assert.strictEqual(report.aggregate.halstead.operators.total, 2);
+                });
 
-            test('aggregate has correct Halstead distinct operators', function () {
-                assert.strictEqual(report.aggregate.halstead.operators.distinct, 2);
-            });
+                test('aggregate has correct Halstead distinct operators', function () {
+                    assert.strictEqual(report.aggregate.halstead.operators.distinct, 2);
+                });
 
-            test('aggregate has correct Halstead total operands', function () {
-                assert.strictEqual(report.aggregate.halstead.operands.total, 5);
-            });
+                test('aggregate has correct Halstead total operands', function () {
+                    assert.strictEqual(report.aggregate.halstead.operands.total, 5);
+                });
 
-            test('aggregate has correct Halstead distinct operands', function () {
-                assert.strictEqual(report.aggregate.halstead.operands.distinct, 5);
+                test('aggregate has correct Halstead distinct operands', function () {
+                    assert.strictEqual(report.aggregate.halstead.operands.distinct, 5);
+                });
             });
-        });
 
-        suite('logical or expression passed as argument:', function () {
-            var report;
+            suite('logical or expression passed as argument:', function () {
+                var report;
 
-            setup(function () {
-                report = escomplex.analyse(espree.parse('parseInt("10", 10 || 8);', { loc: true }), mozWalker);
-            });
+                setup(function () {
+                    report = escomplex.analyse(parser.parse('parseInt("10", 10 || 8);', options), mozWalker);
+                });
 
-            teardown(function () {
-                report = undefined;
-            });
+                teardown(function () {
+                    report = undefined;
+                });
 
-            test('aggregate has correct cyclomatic complexity', function () {
-                assert.strictEqual(report.aggregate.cyclomatic, 2);
+                test('aggregate has correct cyclomatic complexity', function () {
+                    assert.strictEqual(report.aggregate.cyclomatic, 2);
+                });
             });
-        });
 
-        suite('anonymous function passed as argument:', function () {
-            var report;
+            suite('anonymous function passed as argument:', function () {
+                var report;
 
-            setup(function () {
-                report = escomplex.analyse(espree.parse('setTimeout(function () { "foo"; }, 1000);', { loc: true }), mozWalker);
-            });
+                setup(function () {
+                    report = escomplex.analyse(parser.parse('setTimeout(function () { "foo"; }, 1000);', options), mozWalker);
+                });
 
-            teardown(function () {
-                report = undefined;
-            });
+                teardown(function () {
+                    report = undefined;
+                });
 
-            test('aggregate has correct logical lines of code', function () {
-                assert.strictEqual(report.aggregate.sloc.logical, 2);
-            });
+                test('aggregate has correct logical lines of code', function () {
+                    assert.strictEqual(report.aggregate.sloc.logical, 2);
+                });
 
-            test('functions has correct length', function () {
-                assert.lengthOf(report.functions, 1);
-            });
+                test('functions has correct length', function () {
+                    assert.lengthOf(report.functions, 1);
+                });
 
-            test('function is anonymous', function () {
-                assert.strictEqual(report.functions[0].name, '<anonymous>');
-            });
+                test('function is anonymous', function () {
+                    assert.strictEqual(report.functions[0].name, '<anonymous>');
+                });
 
-            test('aggregate has correct Halstead total operators', function () {
-                assert.strictEqual(report.aggregate.halstead.operators.total, 2);
-            });
+                test('aggregate has correct Halstead total operators', function () {
+                    assert.strictEqual(report.aggregate.halstead.operators.total, 2);
+                });
 
-            test('aggregate has correct Halstead distinct operators', function () {
-                assert.strictEqual(report.aggregate.halstead.operators.distinct, 2);
-            });
+                test('aggregate has correct Halstead distinct operators', function () {
+                    assert.strictEqual(report.aggregate.halstead.operators.distinct, 2);
+                });
 
-            test('aggregate has correct Halstead total operands', function () {
-                assert.strictEqual(report.aggregate.halstead.operands.total, 4);
-            });
+                test('aggregate has correct Halstead total operands', function () {
+                    assert.strictEqual(report.aggregate.halstead.operands.total, 4);
+                });
 
-            test('aggregate has correct Halstead distinct operands', function () {
-                assert.strictEqual(report.aggregate.halstead.operands.distinct, 4);
+                test('aggregate has correct Halstead distinct operands', function () {
+                    assert.strictEqual(report.aggregate.halstead.operands.distinct, 4);
+                });
             });
-        });
 
-        suite('named function passed as argument:', function () {
-            var report;
+            suite('named function passed as argument:', function () {
+                var report;
 
-            setup(function () {
-                report = escomplex.analyse(espree.parse('setTimeout(function foo () { "bar"; }, 1000);', { loc: true }), mozWalker);
-            });
+                setup(function () {
+                    report = escomplex.analyse(parser.parse('setTimeout(function foo () { "bar"; }, 1000);', options), mozWalker);
+                });
 
-            teardown(function () {
-                report = undefined;
-            });
+                teardown(function () {
+                    report = undefined;
+                });
 
-            test('function has correct name', function () {
-                assert.strictEqual(report.functions[0].name, 'foo');
+                test('function has correct name', function () {
+                    assert.strictEqual(report.functions[0].name, 'foo');
+                });
             });
-        });
 
-        suite('logical AND expression:', function () {
-            test('aggregate has correct cyclomatic complexity', function () {
-                var report = escomplex.analyse(
-                    espree.parse('var foo = true && false;'),
-                    mozWalker,
-                    {}
-                );
-                assert.strictEqual(report.cyclomatic, 2);
+            suite('logical AND expression:', function () {
+                test('aggregate has correct cyclomatic complexity', function () {
+                    var report = escomplex.analyse(
+                        parser.parse('var foo = true && false;'),
+                        mozWalker,
+                        {}
+                    );
+                    assert.strictEqual(report.cyclomatic, 2);
+                });
             });
-        });
 
-        suite('logical OR expression with logicalor false:', function () {
-            var report;
+            suite('logical OR expression with logicalor false:', function () {
+                var report;
 
-            setup(function () {
-                report = escomplex.analyse(espree.parse('var foo = true || false;', { loc: true }), mozWalker, { logicalor: false });
-            });
+                setup(function () {
+                    report = escomplex.analyse(parser.parse('var foo = true || false;', options), mozWalker, { logicalor: false });
+                });
 
-            teardown(function () {
-                report = undefined;
-            });
+                teardown(function () {
+                    report = undefined;
+                });
 
-            test('aggregate has correct cyclomatic complexity', function () {
-                assert.strictEqual(report.aggregate.cyclomatic, 1);
+                test('aggregate has correct cyclomatic complexity', function () {
+                    assert.strictEqual(report.aggregate.cyclomatic, 1);
+                });
             });
-        });
 
-        suite('switch statement with switchcase false:', function () {
-            var report;
+            suite('switch statement with switchcase false:', function () {
+                var report;
 
-            setup(function () {
-                report = escomplex.analyse(espree.parse('switch (Date.now()) { case 1: "foo"; break; case 2: "bar"; break; default: "baz"; }', { loc: true }), mozWalker, { switchcase: false });
-            });
+                setup(function () {
+                    report = escomplex.analyse(parser.parse('switch (Date.now()) { case 1: "foo"; break; case 2: "bar"; break; default: "baz"; }', options), mozWalker, { switchcase: false });
+                });
 
-            teardown(function () {
-                report = undefined;
-            });
+                teardown(function () {
+                    report = undefined;
+                });
 
-            test('aggregate has correct cyclomatic complexity', function () {
-                assert.strictEqual(report.aggregate.cyclomatic, 1);
+                test('aggregate has correct cyclomatic complexity', function () {
+                    assert.strictEqual(report.aggregate.cyclomatic, 1);
+                });
             });
-        });
 
-        suite('for...in loop with forin true:', function () {
-            var report;
+            suite('for...in loop with forin true:', function () {
+                var report;
 
-            setup(function () {
-                report = escomplex.analyse(espree.parse('var property; for (property in { foo: "bar", baz: "qux" }) { "wibble"; }', { loc: true }), mozWalker, { forin: true });
-            });
+                setup(function () {
+                    report = escomplex.analyse(parser.parse('var property; for (property in { foo: "bar", baz: "qux" }) { "wibble"; }', options), mozWalker, { forin: true });
+                });
 
-            teardown(function () {
-                report = undefined;
-            });
+                teardown(function () {
+                    report = undefined;
+                });
 
-            test('aggregate has correct cyclomatic complexity', function () {
-                assert.strictEqual(report.aggregate.cyclomatic, 2);
+                test('aggregate has correct cyclomatic complexity', function () {
+                    assert.strictEqual(report.aggregate.cyclomatic, 2);
+                });
             });
-        });
 
-        suite('try...catch with trycatch true:', function () {
-            var report;
+            suite('try...catch with trycatch true:', function () {
+                var report;
 
-            setup(function () {
-                report = escomplex.analyse(espree.parse('try { "foo"; } catch (e) { e.message; }', { loc: true }), mozWalker, { trycatch: true });
-            });
+                setup(function () {
+                    report = escomplex.analyse(parser.parse('try { "foo"; } catch (e) { e.message; }', options), mozWalker, { trycatch: true });
+                });
 
-            teardown(function () {
-                report = undefined;
-            });
+                teardown(function () {
+                    report = undefined;
+                });
 
-            test('aggregate has correct cyclomatic complexity', function () {
-                assert.strictEqual(report.aggregate.cyclomatic, 2);
+                test('aggregate has correct cyclomatic complexity', function () {
+                    assert.strictEqual(report.aggregate.cyclomatic, 2);
+                });
             });
-        });
 
-        suite('IIFE:', function () {
-            var report;
+            suite('IIFE:', function () {
+                var report;
 
-            setup(function () {
-                report = escomplex.analyse(espree.parse('(function (foo) { if (foo === "foo") { console.log(foo); return; } "bar"; }("foo"));', { loc: true }), mozWalker);
-            });
+                setup(function () {
+                    report = escomplex.analyse(parser.parse('(function (foo) { if (foo === "foo") { console.log(foo); return; } "bar"; }("foo"));', options), mozWalker);
+                });
 
-            teardown(function () {
-                report = undefined;
-            });
+                teardown(function () {
+                    report = undefined;
+                });
 
-            test('aggregate has correct logical lines of code', function () {
-                assert.strictEqual(report.aggregate.sloc.logical, 6);
-            });
+                test('aggregate has correct logical lines of code', function () {
+                    assert.strictEqual(report.aggregate.sloc.logical, 6);
+                });
 
-            test('functions has correct length', function () {
-                assert.lengthOf(report.functions, 1);
-            });
+                test('functions has correct length', function () {
+                    assert.lengthOf(report.functions, 1);
+                });
 
-            test('function has correct cyclomatic complexity', function () {
-                assert.strictEqual(report.functions[0].cyclomatic, 2);
-            });
+                test('function has correct cyclomatic complexity', function () {
+                    assert.strictEqual(report.functions[0].cyclomatic, 2);
+                });
 
-            test('function has correct parameter count', function () {
-                assert.strictEqual(report.functions[0].params, 1);
-            });
+                test('function has correct parameter count', function () {
+                    assert.strictEqual(report.functions[0].params, 1);
+                });
 
-            test('aggregate has correct cyclomatic complexity', function () {
-                assert.strictEqual(report.aggregate.cyclomatic, 2);
-            });
+                test('aggregate has correct cyclomatic complexity', function () {
+                    assert.strictEqual(report.aggregate.cyclomatic, 2);
+                });
 
-            test('aggregate has correct Halstead total operators', function () {
-                assert.strictEqual(report.aggregate.halstead.operators.total, 7);
-            });
+                test('aggregate has correct Halstead total operators', function () {
+                    assert.strictEqual(report.aggregate.halstead.operators.total, 7);
+                });
 
-            test('aggregate has correct Halstead distinct operators', function () {
-                assert.strictEqual(report.aggregate.halstead.operators.distinct, 6);
-            });
+                test('aggregate has correct Halstead distinct operators', function () {
+                    assert.strictEqual(report.aggregate.halstead.operators.distinct, 6);
+                });
 
-            test('aggregate has correct Halstead total operands', function () {
-                assert.strictEqual(report.aggregate.halstead.operands.total, 9);
-            });
+                test('aggregate has correct Halstead total operands', function () {
+                    assert.strictEqual(report.aggregate.halstead.operands.total, 9);
+                });
 
-            test('aggregate has correct Halstead distinct operands', function () {
-                assert.strictEqual(report.aggregate.halstead.operands.distinct, 6);
-            });
+                test('aggregate has correct Halstead distinct operands', function () {
+                    assert.strictEqual(report.aggregate.halstead.operands.distinct, 6);
+                });
 
-            test('aggregate has correct parameter count', function () {
-                assert.strictEqual(report.aggregate.params, 1);
+                test('aggregate has correct parameter count', function () {
+                    assert.strictEqual(report.aggregate.params, 1);
+                });
             });
-        });
 
-        suite('logical and condition:', function () {
-            var report;
+            suite('logical and condition:', function () {
+                var report;
 
-            setup(function () {
-                report = escomplex.analyse(espree.parse('if ("foo" && "bar") { "baz"; }', { loc: true }), mozWalker);
-            });
+                setup(function () {
+                    report = escomplex.analyse(parser.parse('if ("foo" && "bar") { "baz"; }', options), mozWalker);
+                });
 
-            teardown(function () {
-                report = undefined;
-            });
+                teardown(function () {
+                    report = undefined;
+                });
 
-            test('aggregate has correct logical lines of code', function () {
-                assert.strictEqual(report.aggregate.sloc.logical, 2);
-            });
+                test('aggregate has correct logical lines of code', function () {
+                    assert.strictEqual(report.aggregate.sloc.logical, 2);
+                });
 
-            test('aggregate has correct cyclomatic complexity', function () {
-                assert.strictEqual(report.aggregate.cyclomatic, 3);
-            });
+                test('aggregate has correct cyclomatic complexity', function () {
+                    assert.strictEqual(report.aggregate.cyclomatic, 3);
+                });
 
-            test('aggregate has correct Halstead total operators', function () {
-                assert.strictEqual(report.aggregate.halstead.operators.total, 2);
-            });
+                test('aggregate has correct Halstead total operators', function () {
+                    assert.strictEqual(report.aggregate.halstead.operators.total, 2);
+                });
 
-            test('aggregate has correct Halstead distinct operators', function () {
-                assert.strictEqual(report.aggregate.halstead.operators.distinct, 2);
-            });
+                test('aggregate has correct Halstead distinct operators', function () {
+                    assert.strictEqual(report.aggregate.halstead.operators.distinct, 2);
+                });
 
-            test('aggregate has correct Halstead total operands', function () {
-                assert.strictEqual(report.aggregate.halstead.operands.total, 3);
-            });
+                test('aggregate has correct Halstead total operands', function () {
+                    assert.strictEqual(report.aggregate.halstead.operands.total, 3);
+                });
 
-            test('aggregate has correct Halstead distinct operands', function () {
-                assert.strictEqual(report.aggregate.halstead.operands.distinct, 3);
+                test('aggregate has correct Halstead distinct operands', function () {
+                    assert.strictEqual(report.aggregate.halstead.operands.distinct, 3);
+                });
             });
-        });
 
-        suite('call on function object:', function () {
-            var report;
+            suite('call on function object:', function () {
+                var report;
 
-            setup(function () {
-                report = escomplex.analyse(espree.parse('(function () { "foo"; }).call(this);', { loc: true }), mozWalker);
-            });
+                setup(function () {
+                    report = escomplex.analyse(parser.parse('(function () { "foo"; }).call(this);', options), mozWalker);
+                });
 
-            teardown(function () {
-                report = undefined;
-            });
+                teardown(function () {
+                    report = undefined;
+                });
 
-            test('aggregate has correct logical lines of code', function () {
-                assert.strictEqual(report.aggregate.sloc.logical, 3);
-            });
+                test('aggregate has correct logical lines of code', function () {
+                    assert.strictEqual(report.aggregate.sloc.logical, 3);
+                });
 
-            test('functions has correct length', function () {
-                assert.lengthOf(report.functions, 1);
-            });
+                test('functions has correct length', function () {
+                    assert.lengthOf(report.functions, 1);
+                });
 
-            test('aggregate has correct Halstead total operators', function () {
-                assert.strictEqual(report.aggregate.halstead.operators.total, 3);
-            });
+                test('aggregate has correct Halstead total operators', function () {
+                    assert.strictEqual(report.aggregate.halstead.operators.total, 3);
+                });
 
-            test('aggregate has correct Halstead distinct operators', function () {
-                assert.strictEqual(report.aggregate.halstead.operators.distinct, 3);
-            });
+                test('aggregate has correct Halstead distinct operators', function () {
+                    assert.strictEqual(report.aggregate.halstead.operators.distinct, 3);
+                });
 
-            test('aggregate has correct Halstead total operands', function () {
-                assert.strictEqual(report.aggregate.halstead.operands.total, 4);
-            });
+                test('aggregate has correct Halstead total operands', function () {
+                    assert.strictEqual(report.aggregate.halstead.operands.total, 4);
+                });
 
-            test('aggregate has correct Halstead distinct operands', function () {
-                assert.strictEqual(report.aggregate.halstead.operands.distinct, 4);
+                test('aggregate has correct Halstead distinct operands', function () {
+                    assert.strictEqual(report.aggregate.halstead.operands.distinct, 4);
+                });
             });
-        });
 
-        suite('anonymous function assigned to property:', function () {
-            var report;
+            suite('anonymous function assigned to property:', function () {
+                var report;
 
-            setup(function () {
-                report = escomplex.analyse(espree.parse('var foo = {}; foo.bar = function () { "foobar"; };', { loc: true }), mozWalker);
-            });
+                setup(function () {
+                    report = escomplex.analyse(parser.parse('var foo = {}; foo.bar = function () { "foobar"; };', options), mozWalker);
+                });
 
-            teardown(function () {
-                report = undefined;
-            });
+                teardown(function () {
+                    report = undefined;
+                });
 
-            test('aggregate has correct logical lines of code', function () {
-                assert.strictEqual(report.aggregate.sloc.logical, 3);
-            });
+                test('aggregate has correct logical lines of code', function () {
+                    assert.strictEqual(report.aggregate.sloc.logical, 3);
+                });
 
-            test('functions has correct length', function () {
-                assert.lengthOf(report.functions, 1);
-            });
+                test('functions has correct length', function () {
+                    assert.lengthOf(report.functions, 1);
+                });
 
-            test('function has correct name', function () {
-                assert.strictEqual(report.functions[0].name, 'foo.bar');
-            });
+                test('function has correct name', function () {
+                    assert.strictEqual(report.functions[0].name, 'foo.bar');
+                });
 
-            test('aggregate has correct Halstead total operators', function () {
-                assert.strictEqual(report.aggregate.halstead.operators.total, 6);
-            });
+                test('aggregate has correct Halstead total operators', function () {
+                    assert.strictEqual(report.aggregate.halstead.operators.total, 6);
+                });
 
-            test('aggregate has correct Halstead distinct operators', function () {
-                assert.strictEqual(report.aggregate.halstead.operators.distinct, 5);
-            });
+                test('aggregate has correct Halstead distinct operators', function () {
+                    assert.strictEqual(report.aggregate.halstead.operators.distinct, 5);
+                });
 
-            test('aggregate has correct Halstead total operands', function () {
-                assert.strictEqual(report.aggregate.halstead.operands.total, 6);
-            });
+                test('aggregate has correct Halstead total operands', function () {
+                    assert.strictEqual(report.aggregate.halstead.operands.total, 6);
+                });
 
-            test('aggregate has correct Halstead distinct operands', function () {
-                assert.strictEqual(report.aggregate.halstead.operands.distinct, 4);
+                test('aggregate has correct Halstead distinct operands', function () {
+                    assert.strictEqual(report.aggregate.halstead.operands.distinct, 4);
+                });
             });
-        });
 
-        suite('anonymous function assigned to property of literal:', function () {
-            var report;
+            suite('anonymous function assigned to property of literal:', function () {
+                var report;
 
-            setup(function () {
-                report = escomplex.analyse(espree.parse('"".bar = function () { "bar"; };', { loc: true }), mozWalker);
-            });
+                setup(function () {
+                    report = escomplex.analyse(parser.parse('"".bar = function () { "bar"; };', options), mozWalker);
+                });
 
-            teardown(function () {
-                report = undefined;
-            });
+                teardown(function () {
+                    report = undefined;
+                });
 
-            test('aggregate has correct logical lines of code', function () {
-                assert.strictEqual(report.aggregate.sloc.logical, 2);
-            });
+                test('aggregate has correct logical lines of code', function () {
+                    assert.strictEqual(report.aggregate.sloc.logical, 2);
+                });
 
-            test('functions has correct length', function () {
-                assert.lengthOf(report.functions, 1);
-            });
+                test('functions has correct length', function () {
+                    assert.lengthOf(report.functions, 1);
+                });
 
-            test('function has correct name', function () {
-                assert.strictEqual(report.functions[0].name, '<anonymous>.bar');
+                test('function has correct name', function () {
+                    assert.strictEqual(report.functions[0].name, '<anonymous>.bar');
+                });
             });
-        });
 
-        suite('empty object literal:', function () {
-            var report;
+            suite('empty object literal:', function () {
+                var report;
 
-            setup(function () {
-                report = escomplex.analyse(espree.parse('var foo = {};', { loc: true }), mozWalker);
-            });
+                setup(function () {
+                    report = escomplex.analyse(parser.parse('var foo = {};', options), mozWalker);
+                });
 
-            teardown(function () {
-                report = undefined;
-            });
+                teardown(function () {
+                    report = undefined;
+                });
 
-            test('aggregate has correct logical lines of code', function () {
-                assert.strictEqual(report.aggregate.sloc.logical, 1);
-            });
+                test('aggregate has correct logical lines of code', function () {
+                    assert.strictEqual(report.aggregate.sloc.logical, 1);
+                });
 
-            test('aggregate has correct cyclomatic complexity', function () {
-                assert.strictEqual(report.aggregate.cyclomatic, 1);
-            });
+                test('aggregate has correct cyclomatic complexity', function () {
+                    assert.strictEqual(report.aggregate.cyclomatic, 1);
+                });
 
-            test('functions has correct length', function () {
-                assert.lengthOf(report.functions, 0);
-            });
+                test('functions has correct length', function () {
+                    assert.lengthOf(report.functions, 0);
+                });
 
-            test('aggregate has correct Halstead total operators', function () {
-                assert.strictEqual(report.aggregate.halstead.operators.total, 3);
-            });
+                test('aggregate has correct Halstead total operators', function () {
+                    assert.strictEqual(report.aggregate.halstead.operators.total, 3);
+                });
 
-            test('aggregate has correct Halstead distinct operators', function () {
-                assert.strictEqual(report.aggregate.halstead.operators.distinct, 3);
-            });
+                test('aggregate has correct Halstead distinct operators', function () {
+                    assert.strictEqual(report.aggregate.halstead.operators.distinct, 3);
+                });
 
-            test('aggregate has correct Halstead total operands', function () {
-                assert.strictEqual(report.aggregate.halstead.operands.total, 2);
-            });
+                test('aggregate has correct Halstead total operands', function () {
+                    assert.strictEqual(report.aggregate.halstead.operands.total, 2);
+                });
 
-            test('aggregate has correct Halstead distinct operands', function () {
-                assert.strictEqual(report.aggregate.halstead.operands.distinct, 2);
+                test('aggregate has correct Halstead distinct operands', function () {
+                    assert.strictEqual(report.aggregate.halstead.operands.distinct, 2);
+                });
             });
-        });
 
-        suite('function property of literal object:', function () {
-            var report;
+            suite('function property of literal object:', function () {
+                var report;
 
-            setup(function () {
-                report = escomplex.analyse(espree.parse('var foo = { bar: "bar", baz: function () { "baz"; } };', { loc: true }), mozWalker);
-            });
+                setup(function () {
+                    report = escomplex.analyse(parser.parse('var foo = { bar: "bar", baz: function () { "baz"; } };', options), mozWalker);
+                });
 
-            teardown(function () {
-                report = undefined;
-            });
+                teardown(function () {
+                    report = undefined;
+                });
 
-            test('aggregate has correct logical lines of code', function () {
-                assert.strictEqual(report.aggregate.sloc.logical, 4);
-            });
+                test('aggregate has correct logical lines of code', function () {
+                    assert.strictEqual(report.aggregate.sloc.logical, 4);
+                });
 
-            test('functions has correct length', function () {
-                assert.lengthOf(report.functions, 1);
-            });
+                test('functions has correct length', function () {
+                    assert.lengthOf(report.functions, 1);
+                });
 
-            test('function has correct name', function () {
-                assert.strictEqual(report.functions[0].name, 'baz');
-            });
+                test('function has correct name', function () {
+                    assert.strictEqual(report.functions[0].name, 'baz');
+                });
 
-            test('aggregate has correct Halstead total operators', function () {
-                assert.strictEqual(report.aggregate.halstead.operators.total, 6);
-            });
+                test('aggregate has correct Halstead total operators', function () {
+                    assert.strictEqual(report.aggregate.halstead.operators.total, 6);
+                });
 
-            test('aggregate has correct Halstead distinct operators', function () {
-                assert.strictEqual(report.aggregate.halstead.operators.distinct, 5);
-            });
+                test('aggregate has correct Halstead distinct operators', function () {
+                    assert.strictEqual(report.aggregate.halstead.operators.distinct, 5);
+                });
 
-            test('aggregate has correct Halstead total operands', function () {
-                assert.strictEqual(report.aggregate.halstead.operands.total, 7);
-            });
+                test('aggregate has correct Halstead total operands', function () {
+                    assert.strictEqual(report.aggregate.halstead.operands.total, 7);
+                });
 
-            test('aggregate has correct Halstead distinct operands', function () {
-                assert.strictEqual(report.aggregate.halstead.operands.distinct, 6);
+                test('aggregate has correct Halstead distinct operands', function () {
+                    assert.strictEqual(report.aggregate.halstead.operands.distinct, 6);
+                });
             });
-        });
 
-        suite('duplicate function properties of literal object:', function () {
-            var report;
+            suite('duplicate function properties of literal object:', function () {
+                var report;
 
-            setup(function () {
-                report = escomplex.analyse(espree.parse('var foo = { bar: function () { if (true) { "bar"; } }, bar: function () { "bar"; } };', { loc: true }), mozWalker);
-            });
+                setup(function () {
+                    report = escomplex.analyse(parser.parse('var foo = { bar: function () { if (true) { "bar"; } }, bar: function () { "bar"; } };', options), mozWalker);
+                });
 
-            teardown(function () {
-                report = undefined;
-            });
+                teardown(function () {
+                    report = undefined;
+                });
 
-            test('functions has correct length', function () {
-                assert.lengthOf(report.functions, 2);
-            });
+                test('functions has correct length', function () {
+                    assert.lengthOf(report.functions, 2);
+                });
 
-            test('first function has correct name', function () {
-                assert.strictEqual(report.functions[0].name, 'bar');
-            });
+                test('first function has correct name', function () {
+                    assert.strictEqual(report.functions[0].name, 'bar');
+                });
 
-            test('second function has correct name', function () {
-                assert.strictEqual(report.functions[1].name, 'bar');
-            });
+                test('second function has correct name', function () {
+                    assert.strictEqual(report.functions[1].name, 'bar');
+                });
 
-            test('first function has correct cyclomatic complexity', function () {
-                assert.strictEqual(report.functions[0].cyclomatic, 2);
-            });
+                test('first function has correct cyclomatic complexity', function () {
+                    assert.strictEqual(report.functions[0].cyclomatic, 2);
+                });
 
-            test('second function has correct cyclomatic complexity', function () {
-                assert.strictEqual(report.functions[1].cyclomatic, 1);
-            });
+                test('second function has correct cyclomatic complexity', function () {
+                    assert.strictEqual(report.functions[1].cyclomatic, 1);
+                });
 
-            test('aggregate has correct cyclomatic complexity', function () {
-                assert.strictEqual(report.aggregate.cyclomatic, 2);
+                test('aggregate has correct cyclomatic complexity', function () {
+                    assert.strictEqual(report.aggregate.cyclomatic, 2);
+                });
             });
-        });
 
-        suite('throw exception:', function () {
-            var report;
+            suite('throw exception:', function () {
+                var report;
 
-            setup(function () {
-                report = escomplex.analyse(espree.parse('try { throw new Error("foo"); } catch (e) { alert(error.message); }', { loc: true }), mozWalker);
-            });
+                setup(function () {
+                    report = escomplex.analyse(parser.parse('try { throw new Error("foo"); } catch (e) { alert(error.message); }', options), mozWalker);
+                });
 
-            teardown(function () {
-                report = undefined;
-            });
+                teardown(function () {
+                    report = undefined;
+                });
 
-            test('aggregate has correct logical lines of code', function () {
-                assert.strictEqual(report.aggregate.sloc.logical, 4);
-            });
+                test('aggregate has correct logical lines of code', function () {
+                    assert.strictEqual(report.aggregate.sloc.logical, 4);
+                });
 
-            test('functions has correct length', function () {
-                assert.lengthOf(report.functions, 0);
-            });
+                test('functions has correct length', function () {
+                    assert.lengthOf(report.functions, 0);
+                });
 
-            test('aggregate has correct Halstead total operators', function () {
-                assert.strictEqual(report.aggregate.halstead.operators.total, 5);
-            });
+                test('aggregate has correct Halstead total operators', function () {
+                    assert.strictEqual(report.aggregate.halstead.operators.total, 5);
+                });
 
-            test('aggregate has correct Halstead distinct operators', function () {
-                assert.strictEqual(report.aggregate.halstead.operators.distinct, 5);
-            });
+                test('aggregate has correct Halstead distinct operators', function () {
+                    assert.strictEqual(report.aggregate.halstead.operators.distinct, 5);
+                });
 
-            test('aggregate has correct Halstead total operands', function () {
-                assert.strictEqual(report.aggregate.halstead.operands.total, 6);
-            });
+                test('aggregate has correct Halstead total operands', function () {
+                    assert.strictEqual(report.aggregate.halstead.operands.total, 6);
+                });
 
-            test('aggregate has correct Halstead distinct operands', function () {
-                assert.strictEqual(report.aggregate.halstead.operands.distinct, 6);
+                test('aggregate has correct Halstead distinct operands', function () {
+                    assert.strictEqual(report.aggregate.halstead.operands.distinct, 6);
+                });
             });
-        });
 
-        suite('prefix and postfix increment:', function () {
-            var report;
+            suite('prefix and postfix increment:', function () {
+                var report;
 
-            setup(function () {
-                report = escomplex.analyse(espree.parse('var a = 0; ++a; a++;', { loc: true }), mozWalker);
-            });
+                setup(function () {
+                    report = escomplex.analyse(parser.parse('var a = 0; ++a; a++;', options), mozWalker);
+                });
 
-            teardown(function () {
-                report = undefined;
-            });
+                teardown(function () {
+                    report = undefined;
+                });
 
-            test('aggregate has correct logical lines of code', function () {
-                assert.strictEqual(report.aggregate.sloc.logical, 3);
-            });
+                test('aggregate has correct logical lines of code', function () {
+                    assert.strictEqual(report.aggregate.sloc.logical, 3);
+                });
 
-            test('functions has correct length', function () {
-                assert.lengthOf(report.functions, 0);
-            });
+                test('functions has correct length', function () {
+                    assert.lengthOf(report.functions, 0);
+                });
 
-            test('aggregate has correct cyclomatic complexity', function () {
-                assert.strictEqual(report.aggregate.cyclomatic, 1);
-            });
+                test('aggregate has correct cyclomatic complexity', function () {
+                    assert.strictEqual(report.aggregate.cyclomatic, 1);
+                });
 
-            test('aggregate has correct Halstead total operators', function () {
-                assert.strictEqual(report.aggregate.halstead.operators.total, 4);
-            });
+                test('aggregate has correct Halstead total operators', function () {
+                    assert.strictEqual(report.aggregate.halstead.operators.total, 4);
+                });
 
-            test('aggregate has correct Halstead distinct operators', function () {
-                assert.strictEqual(report.aggregate.halstead.operators.distinct, 4);
-            });
+                test('aggregate has correct Halstead distinct operators', function () {
+                    assert.strictEqual(report.aggregate.halstead.operators.distinct, 4);
+                });
 
-            test('aggregate has correct Halstead total operands', function () {
-                assert.strictEqual(report.aggregate.halstead.operands.total, 4);
-            });
+                test('aggregate has correct Halstead total operands', function () {
+                    assert.strictEqual(report.aggregate.halstead.operands.total, 4);
+                });
 
-            test('aggregate has correct Halstead distinct operands', function () {
-                assert.strictEqual(report.aggregate.halstead.operands.distinct, 2);
+                test('aggregate has correct Halstead distinct operands', function () {
+                    assert.strictEqual(report.aggregate.halstead.operands.distinct, 2);
+                });
             });
-        });
 
-        suite('array literal:', function () {
-            var report;
+            suite('array literal:', function () {
+                var report;
 
-            setup(function () {
-                report = escomplex.analyse(espree.parse('[ "foo", "bar" ];', { loc: true }), mozWalker);
-            });
+                setup(function () {
+                    report = escomplex.analyse(parser.parse('[ "foo", "bar" ];', options), mozWalker);
+                });
 
-            teardown(function () {
-                report = undefined;
-            });
+                teardown(function () {
+                    report = undefined;
+                });
 
-            test('aggregate has correct logical lines of code', function () {
-                assert.strictEqual(report.aggregate.sloc.logical, 1);
-            });
+                test('aggregate has correct logical lines of code', function () {
+                    assert.strictEqual(report.aggregate.sloc.logical, 1);
+                });
 
-            test('functions has correct length', function () {
-                assert.lengthOf(report.functions, 0);
-            });
+                test('functions has correct length', function () {
+                    assert.lengthOf(report.functions, 0);
+                });
 
-            test('aggregate has correct cyclomatic complexity', function () {
-                assert.strictEqual(report.aggregate.cyclomatic, 1);
-            });
+                test('aggregate has correct cyclomatic complexity', function () {
+                    assert.strictEqual(report.aggregate.cyclomatic, 1);
+                });
 
-            test('aggregate has correct Halstead total operators', function () {
-                assert.strictEqual(report.aggregate.halstead.operators.total, 1);
-            });
+                test('aggregate has correct Halstead total operators', function () {
+                    assert.strictEqual(report.aggregate.halstead.operators.total, 1);
+                });
 
-            test('aggregate has correct Halstead distinct operators', function () {
-                assert.strictEqual(report.aggregate.halstead.operators.distinct, 1);
-            });
+                test('aggregate has correct Halstead distinct operators', function () {
+                    assert.strictEqual(report.aggregate.halstead.operators.distinct, 1);
+                });
 
-            test('aggregate has correct Halstead total operands', function () {
-                assert.strictEqual(report.aggregate.halstead.operands.total, 3);
-            });
+                test('aggregate has correct Halstead total operands', function () {
+                    assert.strictEqual(report.aggregate.halstead.operands.total, 3);
+                });
 
-            test('aggregate has correct Halstead distinct operands', function () {
-                assert.strictEqual(report.aggregate.halstead.operands.distinct, 3);
+                test('aggregate has correct Halstead distinct operands', function () {
+                    assert.strictEqual(report.aggregate.halstead.operands.distinct, 3);
+                });
             });
-        });
 
-        suite('multiple physical lines:', function () {
-            var report;
+            suite('multiple physical lines:', function () {
+                var report;
 
-            setup(function () {
-                report = escomplex.analyse(espree.parse('// This is a\n// multi-line\n// comment.\nparseInt(\n\t(function () {\n\t\t// Moar\n\t\t// commentz!\n\t\treturn [\n\t\t\t"1",\n\t\t\t"0"\n\t\t].join("");\n\t}()),\n\t10\n);', { loc: true }), mozWalker);
-            });
+                setup(function () {
+                    report = escomplex.analyse(parser.parse('// This is a\n// multi-line\n// comment.\nparseInt(\n\t(function () {\n\t\t// Moar\n\t\t// commentz!\n\t\treturn [\n\t\t\t"1",\n\t\t\t"0"\n\t\t].join("");\n\t}()),\n\t10\n);', options), mozWalker);
+                });
 
-            teardown(function () {
-                report = undefined;
-            });
+                teardown(function () {
+                    report = undefined;
+                });
 
-            test('aggregate has correct physical lines of code', function () {
-                assert.strictEqual(report.aggregate.sloc.physical, 11);
-            });
+                test('aggregate has correct physical lines of code', function () {
+                    // The acorn parser treats comment lines differently from
+                    // other parsers. Consequently, the starting line value is
+                    // different when calculating the aggregate lines.
+                    if (parserName === 'acorn') {
+                        assert.strictEqual(report.aggregate.sloc.physical, 14);
+                    } else {
+                        assert.strictEqual(report.aggregate.sloc.physical, 11);
+                    }
+                });
 
-            test('aggregate has correct logical lines of code', function () {
-                assert.strictEqual(report.aggregate.sloc.logical, 4);
-            });
+                test('aggregate has correct logical lines of code', function () {
+                    assert.strictEqual(report.aggregate.sloc.logical, 4);
+                });
 
-            test('functions has correct length', function () {
-                assert.lengthOf(report.functions, 1);
-            });
+                test('functions has correct length', function () {
+                    assert.lengthOf(report.functions, 1);
+                });
 
-            test('function has correct physical lines of code', function () {
-                assert.strictEqual(report.functions[0].sloc.physical, 8);
-            });
+                test('function has correct physical lines of code', function () {
+                    assert.strictEqual(report.functions[0].sloc.physical, 8);
+                });
 
-            test('function has correct logical lines of code', function () {
-                assert.strictEqual(report.functions[0].sloc.logical, 2);
-            });
+                test('function has correct logical lines of code', function () {
+                    assert.strictEqual(report.functions[0].sloc.logical, 2);
+                });
 
-            test('maintainability index is correct', function () {
-                assert.strictEqual(Math.round(report.maintainability), 146);
+                test('maintainability index is correct', function () {
+                    assert.strictEqual(Math.round(report.maintainability), 146);
+                });
             });
-        });
 
-        suite('multiple functions:', function () {
-            var report;
+            suite('multiple functions:', function () {
+                var report;
 
-            setup(function () {
-                report = escomplex.analyse(espree.parse('function foo (a, b) { if (a) { b(a); } else { a(b); } } function bar (c, d) { var i; for (i = 0; i < c.length; i += 1) { d += 1; } console.log(d); }', { loc: true }), mozWalker);
-            });
+                setup(function () {
+                    report = escomplex.analyse(parser.parse('function foo (a, b) { if (a) { b(a); } else { a(b); } } function bar (c, d) { var i; for (i = 0; i < c.length; i += 1) { d += 1; } console.log(d); }', options), mozWalker);
+                });
 
-            teardown(function () {
-                report = undefined;
-            });
+                teardown(function () {
+                    report = undefined;
+                });
 
-            test('maintainability index is correct', function () {
-                assert.strictEqual(Math.round(report.maintainability), 128);
-            });
+                test('maintainability index is correct', function () {
+                    assert.strictEqual(Math.round(report.maintainability), 128);
+                });
 
-            test('first function has correct parameter count', function () {
-                assert.strictEqual(report.functions[0].params, 2);
-            });
+                test('first function has correct parameter count', function () {
+                    assert.strictEqual(report.functions[0].params, 2);
+                });
 
-            test('second function has correct parameter count', function () {
-                assert.strictEqual(report.functions[1].params, 2);
-            });
+                test('second function has correct parameter count', function () {
+                    assert.strictEqual(report.functions[1].params, 2);
+                });
 
-            test('aggregate has correct parameter count', function () {
-                assert.strictEqual(report.aggregate.params, 4);
-            });
+                test('aggregate has correct parameter count', function () {
+                    assert.strictEqual(report.aggregate.params, 4);
+                });
 
-            test('mean logical LOC is correct', function () {
-                assert.strictEqual(report.loc, 4);
-            });
+                test('mean logical LOC is correct', function () {
+                    assert.strictEqual(report.loc, 4);
+                });
 
-            test('mean cyclomatic complexity is correct', function () {
-                assert.strictEqual(report.cyclomatic, 2);
-            });
+                test('mean cyclomatic complexity is correct', function () {
+                    assert.strictEqual(report.cyclomatic, 2);
+                });
 
-            test('mean Halstead effort is correct', function () {
-                assert.strictEqual(report.effort, 374.7133081440434);
-            });
+                test('mean Halstead effort is correct', function () {
+                    assert.strictEqual(report.effort, 374.7133081440434);
+                });
 
-            test('mean parameter count is correct', function () {
-                assert.strictEqual(report.params, 2);
+                test('mean parameter count is correct', function () {
+                    assert.strictEqual(report.params, 2);
+                });
             });
-        });
 
-        suite('issue 3 / reddit.ISV_Damocles:', function () {
-            var report;
+            suite('issue 3 / reddit.ISV_Damocles:', function () {
+                var report;
 
-            setup(function () {
-                report = escomplex.analyse(espree.parse('var callback = arguments[arguments.length-1] instanceof Function ? arguments[arguments.length-1] : function() {};', { loc: true }), mozWalker);
-            });
+                setup(function () {
+                    report = escomplex.analyse(parser.parse('var callback = arguments[arguments.length-1] instanceof Function ? arguments[arguments.length-1] : function() {};', options), mozWalker);
+                });
 
-            teardown(function () {
-                report = undefined;
-            });
+                teardown(function () {
+                    report = undefined;
+                });
 
-            test('maintainability index is correct', function () {
-                assert.strictEqual(report.maintainability, 171);
+                test('maintainability index is correct', function () {
+                    assert.strictEqual(report.maintainability, 171);
+                });
             });
-        });
 
-        suite('empty return:', function () {
-            var report;
+            suite('empty return:', function () {
+                var report;
 
-            setup(function () {
-                report = escomplex.analyse(espree.parse('function foo () { return; }', { loc: true }), mozWalker);
-            });
+                setup(function () {
+                    report = escomplex.analyse(parser.parse('function foo () { return; }', options), mozWalker);
+                });
 
-            teardown(function () {
-                report = undefined;
-            });
+                teardown(function () {
+                    report = undefined;
+                });
 
-            test('aggregate has correct Halstead total operators', function () {
-                assert.strictEqual(report.aggregate.halstead.operators.total, 2);
-            });
+                test('aggregate has correct Halstead total operators', function () {
+                    assert.strictEqual(report.aggregate.halstead.operators.total, 2);
+                });
 
-            test('aggregate has correct Halstead distinct operators', function () {
-                assert.strictEqual(report.aggregate.halstead.operators.distinct, 2);
-            });
+                test('aggregate has correct Halstead distinct operators', function () {
+                    assert.strictEqual(report.aggregate.halstead.operators.distinct, 2);
+                });
 
-            test('aggregate has correct Halstead total operands', function () {
-                assert.strictEqual(report.aggregate.halstead.operands.total, 1);
-            });
+                test('aggregate has correct Halstead total operands', function () {
+                    assert.strictEqual(report.aggregate.halstead.operands.total, 1);
+                });
 
-            test('aggregate has correct Halstead distinct operands', function () {
-                assert.strictEqual(report.aggregate.halstead.operands.distinct, 1);
-            });
+                test('aggregate has correct Halstead distinct operands', function () {
+                    assert.strictEqual(report.aggregate.halstead.operands.distinct, 1);
+                });
 
-            test('aggregate has correct Halstead difficulty', function () {
-                assert.strictEqual(report.aggregate.halstead.difficulty, 1);
-            });
+                test('aggregate has correct Halstead difficulty', function () {
+                    assert.strictEqual(report.aggregate.halstead.difficulty, 1);
+                });
 
-            test('function has correct Halstead difficulty', function () {
-                assert.strictEqual(report.functions[0].halstead.difficulty, 0.5);
-            });
+                test('function has correct Halstead difficulty', function () {
+                    assert.strictEqual(report.functions[0].halstead.difficulty, 0.5);
+                });
 
-            test('maintainability index is correct', function () {
-                assert.strictEqual(report.maintainability, 171);
+                test('maintainability index is correct', function () {
+                    assert.strictEqual(report.maintainability, 171);
+                });
             });
-        });
 
-        suite('Empty nested functions', function () {
-            var report;
+            suite('Empty nested functions', function () {
+                var report;
 
-            setup(function () {
-                report = escomplex.analyse(espree.parse('function foo () { function bar () {} }', { loc: true }), mozWalker);
-            });
+                setup(function () {
+                    report = escomplex.analyse(parser.parse('function foo () { function bar () {} }', options), mozWalker);
+                });
 
-            teardown(function () {
-                report = undefined;
-            });
+                teardown(function () {
+                    report = undefined;
+                });
 
-            test('maintainability index is correct', function () {
-                assert.strictEqual(report.maintainability, 171);
+                test('maintainability index is correct', function () {
+                    assert.strictEqual(report.maintainability, 171);
+                });
             });
-        });
 
-        suite('Microsoft variant maintainability index:', function () {
-            var report;
+            suite('Microsoft variant maintainability index:', function () {
+                var report;
 
-            setup(function () {
-                report = escomplex.analyse(espree.parse('function foo (a, b) { if (a) { b(a); } else { a(b); } } function bar (c, d) { var i; for (i = 0; i < c.length; i += 1) { d += 1; } console.log(d); }', { loc: true }), mozWalker, { newmi: true });
-            });
+                setup(function () {
+                    report = escomplex.analyse(parser.parse('function foo (a, b) { if (a) { b(a); } else { a(b); } } function bar (c, d) { var i; for (i = 0; i < c.length; i += 1) { d += 1; } console.log(d); }', options), mozWalker, { newmi: true });
+                });
 
-            teardown(function () {
-                report = undefined;
-            });
+                teardown(function () {
+                    report = undefined;
+                });
 
-            test('maintainability index is correct', function () {
-                assert.strictEqual(Math.round(report.maintainability), 75);
+                test('maintainability index is correct', function () {
+                    assert.strictEqual(Math.round(report.maintainability), 75);
+                });
             });
-        });
 
-        suite('Functions with consistent parameter counts:', function () {
-            var report;
+            suite('Functions with consistent parameter counts:', function () {
+                var report;
 
-            setup(function () {
-                report = escomplex.analyse(espree.parse('function foo (a) {} function bar (b) {} function baz (c) {}', { loc: true }), mozWalker);
-            });
+                setup(function () {
+                    report = escomplex.analyse(parser.parse('function foo (a) {} function bar (b) {} function baz (c) {}', options), mozWalker);
+                });
 
-            teardown(function () {
-                report = undefined;
-            });
+                teardown(function () {
+                    report = undefined;
+                });
 
-            test('aggregate has correct parameter count', function () {
-                assert.strictEqual(report.aggregate.params, 3);
-            });
+                test('aggregate has correct parameter count', function () {
+                    assert.strictEqual(report.aggregate.params, 3);
+                });
 
-            test('mean parameter count is correct', function () {
-                assert.strictEqual(report.params, 1);
+                test('mean parameter count is correct', function () {
+                    assert.strictEqual(report.params, 1);
+                });
             });
-        });
 
-        suite('Functions with inconsistent parameter counts:', function () {
-            var report;
+            suite('Functions with inconsistent parameter counts:', function () {
+                var report;
 
-            setup(function () {
-                report = escomplex.analyse(espree.parse('function foo (a, b, c, d, e) {} function bar (a, b, c, d, e) {} function baz (a) {}', { loc: true }), mozWalker);
-            });
+                setup(function () {
+                    report = escomplex.analyse(parser.parse('function foo (a, b, c, d, e) {} function bar (a, b, c, d, e) {} function baz (a) {}', options), mozWalker);
+                });
 
-            teardown(function () {
-                report = undefined;
-            });
+                teardown(function () {
+                    report = undefined;
+                });
 
-            test('aggregate has correct parameter count', function () {
-                assert.strictEqual(report.aggregate.params, 11);
-            });
+                test('aggregate has correct parameter count', function () {
+                    assert.strictEqual(report.aggregate.params, 11);
+                });
 
-            test('mean parameter count is correct', function () {
-                assert.strictEqual(report.params, 11/3);
+                test('mean parameter count is correct', function () {
+                    assert.strictEqual(report.params, 11/3);
+                });
             });
-        });
 
-        suite('CommonJS require literal:', function () {
-            var report;
+            suite('CommonJS require literal:', function () {
+                var report;
 
-            setup(function () {
-                report = escomplex.analyse(espree.parse('require("./foo");', { loc: true }), mozWalker);
-            });
+                setup(function () {
+                    report = escomplex.analyse(parser.parse('require("./foo");', options), mozWalker);
+                });
 
-            teardown(function () {
-                report = undefined;
-            });
+                teardown(function () {
+                    report = undefined;
+                });
 
-            test('dependencies has correct length', function () {
-                assert.lengthOf(report.dependencies, 1);
-            });
+                test('dependencies has correct length', function () {
+                    assert.lengthOf(report.dependencies, 1);
+                });
 
-            test('dependencies are correct', function () {
-                assert.isObject(report.dependencies[0]);
-                assert.strictEqual(report.dependencies[0].line, 1);
-                assert.strictEqual(report.dependencies[0].path, './foo');
-                assert.strictEqual(report.dependencies[0].type, 'CommonJS');
+                test('dependencies are correct', function () {
+                    assert.isObject(report.dependencies[0]);
+                    assert.strictEqual(report.dependencies[0].line, 1);
+                    assert.strictEqual(report.dependencies[0].path, './foo');
+                    assert.strictEqual(report.dependencies[0].type, 'CommonJS');
+                });
             });
-        });
 
-        suite('alternative CommonJS require literal:', function () {
-            var report;
+            suite('alternative CommonJS require literal:', function () {
+                var report;
 
-            setup(function () {
-                report = escomplex.analyse(espree.parse('require("./bar");', { loc: true }), mozWalker);
-            });
+                setup(function () {
+                    report = escomplex.analyse(parser.parse('require("./bar");', options), mozWalker);
+                });
 
-            teardown(function () {
-                report = undefined;
-            });
+                teardown(function () {
+                    report = undefined;
+                });
 
-            test('dependencies are correct', function () {
-                assert.strictEqual(report.dependencies[0].path, './bar');
+                test('dependencies are correct', function () {
+                    assert.strictEqual(report.dependencies[0].path, './bar');
+                });
             });
-        });
 
-        suite('CommonJS require multiple:', function () {
-            var report;
+            suite('CommonJS require multiple:', function () {
+                var report;
 
-            setup(function () {
-                report = escomplex.analyse(espree.parse('require("./foo");\nrequire("./bar");\n\nrequire("./baz");', { loc: true }), mozWalker);
-            });
+                setup(function () {
+                    report = escomplex.analyse(parser.parse('require("./foo");\nrequire("./bar");\n\nrequire("./baz");', options), mozWalker);
+                });
 
-            teardown(function () {
-                report = undefined;
-            });
+                teardown(function () {
+                    report = undefined;
+                });
 
-            test('dependencies has correct length', function () {
-                assert.lengthOf(report.dependencies, 3);
-            });
+                test('dependencies has correct length', function () {
+                    assert.lengthOf(report.dependencies, 3);
+                });
 
-            test('dependencies are correct', function () {
-                assert.strictEqual(report.dependencies[0].line, 1);
-                assert.strictEqual(report.dependencies[0].path, './foo');
-                assert.strictEqual(report.dependencies[1].line, 2);
-                assert.strictEqual(report.dependencies[1].path, './bar');
-                assert.strictEqual(report.dependencies[2].line, 4);
-                assert.strictEqual(report.dependencies[2].path, './baz');
+                test('dependencies are correct', function () {
+                    assert.strictEqual(report.dependencies[0].line, 1);
+                    assert.strictEqual(report.dependencies[0].path, './foo');
+                    assert.strictEqual(report.dependencies[1].line, 2);
+                    assert.strictEqual(report.dependencies[1].path, './bar');
+                    assert.strictEqual(report.dependencies[2].line, 4);
+                    assert.strictEqual(report.dependencies[2].path, './baz');
+                });
             });
-        });
 
-        suite('CommonJS require variable:', function () {
-            var report;
+            suite('CommonJS require variable:', function () {
+                var report;
 
-            setup(function () {
-                report = escomplex.analyse(espree.parse('var foo = "./foo";require(foo);', { loc: true }), mozWalker);
-            });
+                setup(function () {
+                    report = escomplex.analyse(parser.parse('var foo = "./foo";require(foo);', options), mozWalker);
+                });
 
-            teardown(function () {
-                report = undefined;
-            });
+                teardown(function () {
+                    report = undefined;
+                });
 
-            test('dependencies has correct length', function () {
-                assert.lengthOf(report.dependencies, 1);
-            });
+                test('dependencies has correct length', function () {
+                    assert.lengthOf(report.dependencies, 1);
+                });
 
-            test('dependencies are correct', function () {
-                assert.isObject(report.dependencies[0]);
-                assert.strictEqual(report.dependencies[0].line, 1);
-                assert.strictEqual(report.dependencies[0].path, '* dynamic dependency *');
-                assert.strictEqual(report.dependencies[0].type, 'CommonJS');
+                test('dependencies are correct', function () {
+                    assert.isObject(report.dependencies[0]);
+                    assert.strictEqual(report.dependencies[0].line, 1);
+                    assert.strictEqual(report.dependencies[0].path, '* dynamic dependency *');
+                    assert.strictEqual(report.dependencies[0].type, 'CommonJS');
+                });
             });
-        });
 
-        suite('AMD require literal:', function () {
-            var report;
+            suite('AMD require literal:', function () {
+                var report;
 
-            setup(function () {
-                report = escomplex.analyse(espree.parse('require([ "foo" ], function (foo) {});', { loc: true }), mozWalker);
-            });
+                setup(function () {
+                    report = escomplex.analyse(parser.parse('require([ "foo" ], function (foo) {});', options), mozWalker);
+                });
 
-            teardown(function () {
-                report = undefined;
-            });
+                teardown(function () {
+                    report = undefined;
+                });
 
-            test('dependencies has correct length', function () {
-                assert.lengthOf(report.dependencies, 1);
-            });
+                test('dependencies has correct length', function () {
+                    assert.lengthOf(report.dependencies, 1);
+                });
 
-            test('dependencies are correct', function () {
-                assert.isObject(report.dependencies[0]);
-                assert.strictEqual(report.dependencies[0].line, 1);
-                assert.strictEqual(report.dependencies[0].path, 'foo');
-                assert.strictEqual(report.dependencies[0].type, 'AMD');
+                test('dependencies are correct', function () {
+                    assert.isObject(report.dependencies[0]);
+                    assert.strictEqual(report.dependencies[0].line, 1);
+                    assert.strictEqual(report.dependencies[0].path, 'foo');
+                    assert.strictEqual(report.dependencies[0].type, 'AMD');
+                });
             });
-        });
 
-        suite('alternative AMD require literal:', function () {
-            var report;
+            suite('alternative AMD require literal:', function () {
+                var report;
 
-            setup(function () {
-                report = escomplex.analyse(espree.parse('require([ "bar" ], function (barModule) {});', { loc: true }), mozWalker);
-            });
+                setup(function () {
+                    report = escomplex.analyse(parser.parse('require([ "bar" ], function (barModule) {});', options), mozWalker);
+                });
 
-            teardown(function () {
-                report = undefined;
-            });
+                teardown(function () {
+                    report = undefined;
+                });
 
-            test('dependencies are correct', function () {
-                assert.strictEqual(report.dependencies[0].path, 'bar');
+                test('dependencies are correct', function () {
+                    assert.strictEqual(report.dependencies[0].path, 'bar');
+                });
             });
-        });
 
-        suite('AMD require multiple:', function () {
-            var report;
+            suite('AMD require multiple:', function () {
+                var report;
 
-            setup(function () {
-                report = escomplex.analyse(espree.parse('require([ "foo", "bar", "baz" ], function (foo, bar, baz) {});', { loc: true }), mozWalker);
-            });
+                setup(function () {
+                    report = escomplex.analyse(parser.parse('require([ "foo", "bar", "baz" ], function (foo, bar, baz) {});', options), mozWalker);
+                });
 
-            teardown(function () {
-                report = undefined;
-            });
+                teardown(function () {
+                    report = undefined;
+                });
 
-            test('dependencies has correct length', function () {
-                assert.lengthOf(report.dependencies, 3);
-            });
+                test('dependencies has correct length', function () {
+                    assert.lengthOf(report.dependencies, 3);
+                });
 
-            test('dependencies are correct', function () {
-                assert.strictEqual(report.dependencies[0].line, 1);
-                assert.strictEqual(report.dependencies[0].path, 'foo');
-                assert.strictEqual(report.dependencies[1].line, 1);
-                assert.strictEqual(report.dependencies[1].path, 'bar');
-                assert.strictEqual(report.dependencies[2].line, 1);
-                assert.strictEqual(report.dependencies[2].path, 'baz');
-                assert.strictEqual(report.dependencies[2].type, 'AMD');
+                test('dependencies are correct', function () {
+                    assert.strictEqual(report.dependencies[0].line, 1);
+                    assert.strictEqual(report.dependencies[0].path, 'foo');
+                    assert.strictEqual(report.dependencies[1].line, 1);
+                    assert.strictEqual(report.dependencies[1].path, 'bar');
+                    assert.strictEqual(report.dependencies[2].line, 1);
+                    assert.strictEqual(report.dependencies[2].path, 'baz');
+                    assert.strictEqual(report.dependencies[2].type, 'AMD');
+                });
             });
-        });
 
-        suite('AMD require variable:', function () {
-            var report;
+            suite('AMD require variable:', function () {
+                var report;
 
-            setup(function () {
-                report = escomplex.analyse(espree.parse('var foo = "foo";\nrequire([ foo ], function (foo) {});', { loc: true }), mozWalker);
-            });
+                setup(function () {
+                    report = escomplex.analyse(parser.parse('var foo = "foo";\nrequire([ foo ], function (foo) {});', options), mozWalker);
+                });
 
-            teardown(function () {
-                report = undefined;
-            });
+                teardown(function () {
+                    report = undefined;
+                });
 
-            test('dependencies has correct length', function () {
-                assert.lengthOf(report.dependencies, 1);
-            });
+                test('dependencies has correct length', function () {
+                    assert.lengthOf(report.dependencies, 1);
+                });
 
-            test('dependencies are correct', function () {
-                assert.strictEqual(report.dependencies[0].line, 2);
-                assert.strictEqual(report.dependencies[0].path, '* dynamic dependency *');
-                assert.strictEqual(report.dependencies[0].type, 'AMD');
+                test('dependencies are correct', function () {
+                    assert.strictEqual(report.dependencies[0].line, 2);
+                    assert.strictEqual(report.dependencies[0].path, '* dynamic dependency *');
+                    assert.strictEqual(report.dependencies[0].type, 'AMD');
+                });
             });
-        });
 
-        suite('AMD require variable array:', function () {
-            var report;
+            suite('AMD require variable array:', function () {
+                var report;
 
-            setup(function () {
-                report = escomplex.analyse(espree.parse('var foo = [ "foo" ];\nrequire(foo, function (foo) {});', { loc: true }), mozWalker);
-            });
+                setup(function () {
+                    report = escomplex.analyse(parser.parse('var foo = [ "foo" ];\nrequire(foo, function (foo) {});', options), mozWalker);
+                });
 
-            teardown(function () {
-                report = undefined;
-            });
+                teardown(function () {
+                    report = undefined;
+                });
 
-            test('dependencies has correct length', function () {
-                assert.lengthOf(report.dependencies, 1);
-            });
+                test('dependencies has correct length', function () {
+                    assert.lengthOf(report.dependencies, 1);
+                });
 
-            test('dependencies are correct', function () {
-                assert.strictEqual(report.dependencies[0].line, 2);
-                assert.strictEqual(report.dependencies[0].path, '* dynamic dependencies *');
+                test('dependencies are correct', function () {
+                    assert.strictEqual(report.dependencies[0].line, 2);
+                    assert.strictEqual(report.dependencies[0].path, '* dynamic dependencies *');
+                });
             });
-        });
 
-        suite('AMD require.config:', function () {
-            var report;
+            suite('AMD require.config:', function () {
+                var report;
 
-            setup(function () {
-                report = escomplex.analyse(espree.parse('require.config({\n\tpaths: {\n\t\tfoo: "path/to/foo",\n\t\tbaz: "../wibble"\n\t}\n});\nrequire([ "foo", "bar", "baz" ], function (foo, bar, baz) {});', { loc: true }), mozWalker);
-            });
+                setup(function () {
+                    report = escomplex.analyse(parser.parse('require.config({\n\tpaths: {\n\t\tfoo: "path/to/foo",\n\t\tbaz: "../wibble"\n\t}\n});\nrequire([ "foo", "bar", "baz" ], function (foo, bar, baz) {});', options), mozWalker);
+                });
 
-            teardown(function () {
-                report = undefined;
-            });
+                teardown(function () {
+                    report = undefined;
+                });
 
-            test('dependencies has correct length', function () {
-                assert.lengthOf(report.dependencies, 3);
-            });
+                test('dependencies has correct length', function () {
+                    assert.lengthOf(report.dependencies, 3);
+                });
 
-            test('dependencies are correct', function () {
-                assert.strictEqual(report.dependencies[0].line, 7);
-                assert.strictEqual(report.dependencies[0].path, 'path/to/foo');
-                assert.strictEqual(report.dependencies[0].type, 'AMD');
-                assert.strictEqual(report.dependencies[1].line, 7);
-                assert.strictEqual(report.dependencies[1].path, 'bar');
-                assert.strictEqual(report.dependencies[0].type, 'AMD');
-                assert.strictEqual(report.dependencies[2].line, 7);
-                assert.strictEqual(report.dependencies[2].path, '../wibble');
-                assert.strictEqual(report.dependencies[0].type, 'AMD');
+                test('dependencies are correct', function () {
+                    assert.strictEqual(report.dependencies[0].line, 7);
+                    assert.strictEqual(report.dependencies[0].path, 'path/to/foo');
+                    assert.strictEqual(report.dependencies[0].type, 'AMD');
+                    assert.strictEqual(report.dependencies[1].line, 7);
+                    assert.strictEqual(report.dependencies[1].path, 'bar');
+                    assert.strictEqual(report.dependencies[0].type, 'AMD');
+                    assert.strictEqual(report.dependencies[2].line, 7);
+                    assert.strictEqual(report.dependencies[2].path, '../wibble');
+                    assert.strictEqual(report.dependencies[0].type, 'AMD');
+                });
             });
-        });
 
-        suite('AMD require literal string:', function () {
-            var report;
+            suite('AMD require literal string:', function () {
+                var report;
 
-            setup(function () {
-                report = escomplex.analyse(espree.parse('require("foo", function (foo) {});', { loc: true }), mozWalker);
-            });
+                setup(function () {
+                    report = escomplex.analyse(parser.parse('require("foo", function (foo) {});', options), mozWalker);
+                });
 
-            teardown(function () {
-                report = undefined;
-            });
+                teardown(function () {
+                    report = undefined;
+                });
 
-            test('dependencies has correct length', function () {
-                assert.lengthOf(report.dependencies, 1);
-            });
+                test('dependencies has correct length', function () {
+                    assert.lengthOf(report.dependencies, 1);
+                });
 
-            test('dependencies are correct', function () {
-                assert.strictEqual(report.dependencies[0].line, 1);
-                assert.strictEqual(report.dependencies[0].path, 'foo');
-                assert.strictEqual(report.dependencies[0].type, 'AMD');
+                test('dependencies are correct', function () {
+                    assert.strictEqual(report.dependencies[0].line, 1);
+                    assert.strictEqual(report.dependencies[0].path, 'foo');
+                    assert.strictEqual(report.dependencies[0].type, 'AMD');
+                });
             });
-        });
 
-        suite('Missing loc data:', function () {
-            var report;
+            suite('Missing loc data:', function () {
+                var report;
 
-            setup(function () {
-                report = escomplex.analyse(espree.parse('parseInt("10", 10);'), mozWalker);
-            });
+                setup(function () {
+                    report = escomplex.analyse(parser.parse('parseInt("10", 10);'), mozWalker);
+                });
 
-            teardown(function () {
-                report = undefined;
-            });
+                teardown(function () {
+                    report = undefined;
+                });
 
-            test('aggregate has correct no physical lines of code', function () {
-                assert.isUndefined(report.aggregate.sloc.physical);
-            });
+                test('aggregate has correct no physical lines of code', function () {
+                    assert.isUndefined(report.aggregate.sloc.physical);
+                });
 
-            test('aggregate has correct logical lines of code', function () {
-                assert.strictEqual(report.aggregate.sloc.logical, 1);
-            });
+                test('aggregate has correct logical lines of code', function () {
+                    assert.strictEqual(report.aggregate.sloc.logical, 1);
+                });
 
-            test('aggregate has correct cyclomatic complexity', function () {
-                assert.strictEqual(report.aggregate.cyclomatic, 1);
-            });
+                test('aggregate has correct cyclomatic complexity', function () {
+                    assert.strictEqual(report.aggregate.cyclomatic, 1);
+                });
 
-            test('functions is empty', function () {
-                assert.lengthOf(report.functions, 0);
-            });
+                test('functions is empty', function () {
+                    assert.lengthOf(report.functions, 0);
+                });
 
-            test('aggregate has correct Halstead total operators', function () {
-                assert.strictEqual(report.aggregate.halstead.operators.total, 1);
-            });
+                test('aggregate has correct Halstead total operators', function () {
+                    assert.strictEqual(report.aggregate.halstead.operators.total, 1);
+                });
 
-            test('aggregate has correct Halstead distinct operators', function () {
-                assert.strictEqual(report.aggregate.halstead.operators.distinct, 1);
-            });
+                test('aggregate has correct Halstead distinct operators', function () {
+                    assert.strictEqual(report.aggregate.halstead.operators.distinct, 1);
+                });
 
-            test('aggregate has correct Halstead total operands', function () {
-                assert.strictEqual(report.aggregate.halstead.operands.total, 3);
-            });
+                test('aggregate has correct Halstead total operands', function () {
+                    assert.strictEqual(report.aggregate.halstead.operands.total, 3);
+                });
 
-            test('aggregate has correct Halstead distinct operands', function () {
-                assert.strictEqual(report.aggregate.halstead.operands.distinct, 3);
-            });
+                test('aggregate has correct Halstead distinct operands', function () {
+                    assert.strictEqual(report.aggregate.halstead.operands.distinct, 3);
+                });
 
-            test('aggregate has correct Halstead operator identifier length', function () {
-                assert.lengthOf(
-                    report.aggregate.halstead.operators.identifiers,
-                    report.aggregate.halstead.operators.distinct
-                );
-            });
+                test('aggregate has correct Halstead operator identifier length', function () {
+                    assert.lengthOf(
+                        report.aggregate.halstead.operators.identifiers,
+                        report.aggregate.halstead.operators.distinct
+                    );
+                });
 
-            test('aggregate has correct Halstead operand identifier length', function () {
-                assert.lengthOf(
-                    report.aggregate.halstead.operands.identifiers,
-                    report.aggregate.halstead.operands.distinct
-                );
-            });
+                test('aggregate has correct Halstead operand identifier length', function () {
+                    assert.lengthOf(
+                        report.aggregate.halstead.operands.identifiers,
+                        report.aggregate.halstead.operands.distinct
+                    );
+                });
 
-            test('aggregate has correct Halstead length', function () {
-                assert.strictEqual(report.aggregate.halstead.length, 4);
-            });
+                test('aggregate has correct Halstead length', function () {
+                    assert.strictEqual(report.aggregate.halstead.length, 4);
+                });
 
-            test('aggregate has correct Halstead vocabulary', function () {
-                assert.strictEqual(report.aggregate.halstead.vocabulary, 4);
-            });
+                test('aggregate has correct Halstead vocabulary', function () {
+                    assert.strictEqual(report.aggregate.halstead.vocabulary, 4);
+                });
 
-            test('aggregate has correct Halstead difficulty', function () {
-                assert.strictEqual(report.aggregate.halstead.difficulty, 0.5);
-            });
+                test('aggregate has correct Halstead difficulty', function () {
+                    assert.strictEqual(report.aggregate.halstead.difficulty, 0.5);
+                });
 
-            test('aggregate has correct Halstead volume', function () {
-                assert.strictEqual(report.aggregate.halstead.volume, 8);
-            });
+                test('aggregate has correct Halstead volume', function () {
+                    assert.strictEqual(report.aggregate.halstead.volume, 8);
+                });
 
-            test('aggregate has correct Halstead effort', function () {
-                assert.strictEqual(report.aggregate.halstead.effort, 4);
-            });
+                test('aggregate has correct Halstead effort', function () {
+                    assert.strictEqual(report.aggregate.halstead.effort, 4);
+                });
 
-            test('aggregate has correct Halstead bugs', function () {
-                assert.strictEqual(Math.round(report.aggregate.halstead.bugs), 0);
-            });
+                test('aggregate has correct Halstead bugs', function () {
+                    assert.strictEqual(Math.round(report.aggregate.halstead.bugs), 0);
+                });
 
-            test('aggregate has correct Halstead time', function () {
-                assert.strictEqual(Math.round(report.aggregate.halstead.time), 0);
-            });
+                test('aggregate has correct Halstead time', function () {
+                    assert.strictEqual(Math.round(report.aggregate.halstead.time), 0);
+                });
 
-            test('maintainability index is correct', function () {
-                assert.strictEqual(Math.round(report.maintainability), 166);
-            });
+                test('maintainability index is correct', function () {
+                    assert.strictEqual(Math.round(report.maintainability), 166);
+                });
 
-            test('aggregate has correct parameter count', function () {
-                assert.strictEqual(report.aggregate.params, 0);
-            });
+                test('aggregate has correct parameter count', function () {
+                    assert.strictEqual(report.aggregate.params, 0);
+                });
 
-            test('mean parameter count is correct', function () {
-                assert.strictEqual(report.params, 0);
-            });
+                test('mean parameter count is correct', function () {
+                    assert.strictEqual(report.params, 0);
+                });
 
-            test('dependencies is correct', function () {
-                assert.lengthOf(report.dependencies, 0);
+                test('dependencies is correct', function () {
+                    assert.lengthOf(report.dependencies, 0);
+                });
             });
         });
-
     });
 });

--- a/test/project.js
+++ b/test/project.js
@@ -4,7 +4,7 @@
 
 var assert = require('chai').assert;
 var mozWalker = require('../src/walker');
-var espree = require('espree');
+var parsers = require('./helpers/parsers');
 var modulePath = '../src/project';
 
 suite('project:', function () {
@@ -123,417 +123,419 @@ suite('project:', function () {
             });
         });
 
-        suite('two modules:', function () {
-            var result;
+        parsers.forEach(function (parserName, parser, options) {
+            suite('two modules:', function () {
+                var result;
 
-            setup(function () {
-                result = cr.analyse([
-                    { ast: espree.parse('function foo (a, b) { if (a) { b(a); } else { a(b); } } function bar (c, d) { var i; for (i = 0; i < c.length; i += 1) { d += 1; } console.log(d); }', { loc: true }), path: 'b' },
-                    { ast: espree.parse('if (true) { "foo"; } else { "bar"; }', { loc: true }), path: 'a' }
-                ], mozWalker);
-            });
-
-            teardown(function () {
-                result = undefined;
-            });
-
-            test('reports is correct length', function () {
-                assert.lengthOf(result.reports, 2);
-            });
-
-            test('first report aggregate has correct physical lines of code', function () {
-                assert.strictEqual(result.reports[0].aggregate.sloc.physical, 1);
-            });
-
-            test('first report aggregate has correct logical lines of code', function () {
-                assert.strictEqual(result.reports[0].aggregate.sloc.logical, 4);
-            });
-
-            test('first report aggregate has correct cyclomatic complexity', function () {
-                assert.strictEqual(result.reports[0].aggregate.cyclomatic, 2);
-            });
-
-            test('first report aggregate has correct cyclomatic complexity density', function () {
-                assert.strictEqual(result.reports[0].aggregate.cyclomaticDensity, 50);
-            });
-
-            test('first report functions is empty', function () {
-                assert.lengthOf(result.reports[0].functions, 0);
-            });
-
-            test('first report aggregate has correct Halstead total operators', function () {
-                assert.strictEqual(result.reports[0].aggregate.halstead.operators.total, 2);
-            });
-
-            test('first report aggregate has correct Halstead distinct operators', function () {
-                assert.strictEqual(result.reports[0].aggregate.halstead.operators.distinct, 2);
-            });
-
-            test('first report aggregate has correct Halstead total operands', function () {
-                assert.strictEqual(result.reports[0].aggregate.halstead.operands.total, 3);
-            });
-
-            test('first report aggregate has correct Halstead distinct operands', function () {
-                assert.strictEqual(result.reports[0].aggregate.halstead.operands.distinct, 3);
-            });
-
-            test('first report aggregate has correct Halstead operator identifier length', function () {
-                assert.lengthOf(
-                    result.reports[0].aggregate.halstead.operators.identifiers,
-                    result.reports[0].aggregate.halstead.operators.distinct
-                );
-            });
-
-            test('first report aggregate has correct Halstead operand identifier length', function () {
-                assert.lengthOf(
-                    result.reports[0].aggregate.halstead.operands.identifiers,
-                    result.reports[0].aggregate.halstead.operands.distinct
-                );
-            });
-
-            test('first report aggregate has correct Halstead length', function () {
-                assert.strictEqual(result.reports[0].aggregate.halstead.length, 5);
-            });
-
-            test('first report aggregate has correct Halstead vocabulary', function () {
-                assert.strictEqual(result.reports[0].aggregate.halstead.vocabulary, 5);
-            });
-
-            test('first report aggregate has correct Halstead difficulty', function () {
-                assert.strictEqual(result.reports[0].aggregate.halstead.difficulty, 1);
-            });
-
-            test('first report aggregate has correct Halstead volume', function () {
-                assert.strictEqual(Math.round(result.reports[0].aggregate.halstead.volume), 12);
-            });
-
-            test('first report aggregate has correct Halstead effort', function () {
-                assert.strictEqual(Math.round(result.reports[0].aggregate.halstead.effort), 12);
-            });
-
-            test('first report aggregate has correct Halstead bugs', function () {
-                assert.strictEqual(Math.round(result.reports[0].aggregate.halstead.bugs), 0);
-            });
-
-            test('first report aggregate has correct Halstead time', function () {
-                assert.strictEqual(Math.round(result.reports[0].aggregate.halstead.time), 1);
-            });
-
-            test('first report has correct path', function () {
-                assert.strictEqual(result.reports[0].path, 'a');
-            });
-
-            test('second report maintainability index is correct', function () {
-                assert.strictEqual(Math.round(result.reports[1].maintainability), 128);
-            });
-
-            test('second report first function has correct parameter count', function () {
-                assert.strictEqual(result.reports[1].functions[0].params, 2);
-            });
-
-            test('second report second function has correct parameter count', function () {
-                assert.strictEqual(result.reports[1].functions[1].params, 2);
-            });
-
-            test('second report aggregate has correct parameter count', function () {
-                assert.strictEqual(result.reports[1].aggregate.params, 4);
-            });
-
-            test('second report mean parameter count is correct', function () {
-                assert.strictEqual(result.reports[1].params, 2);
-            });
-
-            test('second report has correct path', function () {
-                assert.strictEqual(result.reports[1].path, 'b');
-            });
-
-            test('first-order density is correct', function () {
-                assert.strictEqual(result.firstOrderDensity, 0);
-            });
-
-            test('change cost is correct', function () {
-                assert.strictEqual(result.changeCost, 50);
-            });
-
-            test('core size is correct', function () {
-                assert.strictEqual(result.coreSize, 0);
-            });
-
-            test('mean per-function logical LOC is correct', function () {
-                assert.strictEqual(result.loc, 4);
-            });
-
-            test('mean per-function cyclomatic complexity is correct', function () {
-                assert.strictEqual(result.cyclomatic, 2);
-            });
-
-            test('mean per-function Halstead effort is correct', function () {
-                assert.strictEqual(result.effort, 193.1614743092401);
-            });
-
-            test('mean per-function parameter count is correct', function () {
-                assert.strictEqual(result.params, 1);
-            });
-
-            test('mean per-function maintainability index is correct', function () {
-                assert.strictEqual(result.maintainability, 134.05623254229997);
-            });
-        });
-
-        suite('two modules with different options:', function() {
-            var modules = [], reportsOnly;
-            setup(function() {
-                modules.push({
-                    ast: espree.parse('function foo (a, b) { if (a) { b(a); } else { a(b); } } function bar (c, d) { var i; for (i = 0; i < c.length; i += 1) { d += 1; } console.log(d); }', { loc: true }),
-                    path: 'b'
+                setup(function () {
+                    result = cr.analyse([
+                        { ast: parser.parse('function foo (a, b) { if (a) { b(a); } else { a(b); } } function bar (c, d) { var i; for (i = 0; i < c.length; i += 1) { d += 1; } console.log(d); }', options), path: 'b' },
+                        { ast: parser.parse('if (true) { "foo"; } else { "bar"; }', options), path: 'a' }
+                    ], mozWalker);
                 });
-                modules.push({ ast: espree.parse('if (true) { "foo"; } else { "bar"; }', { loc: true }), path: 'a' });
-                reportsOnly = cr.analyse(modules, mozWalker, {skipCalculation: true});
+
+                teardown(function () {
+                    result = undefined;
+                });
+
+                test('reports is correct length', function () {
+                    assert.lengthOf(result.reports, 2);
+                });
+
+                test('first report aggregate has correct physical lines of code', function () {
+                    assert.strictEqual(result.reports[0].aggregate.sloc.physical, 1);
+                });
+
+                test('first report aggregate has correct logical lines of code', function () {
+                    assert.strictEqual(result.reports[0].aggregate.sloc.logical, 4);
+                });
+
+                test('first report aggregate has correct cyclomatic complexity', function () {
+                    assert.strictEqual(result.reports[0].aggregate.cyclomatic, 2);
+                });
+
+                test('first report aggregate has correct cyclomatic complexity density', function () {
+                    assert.strictEqual(result.reports[0].aggregate.cyclomaticDensity, 50);
+                });
+
+                test('first report functions is empty', function () {
+                    assert.lengthOf(result.reports[0].functions, 0);
+                });
+
+                test('first report aggregate has correct Halstead total operators', function () {
+                    assert.strictEqual(result.reports[0].aggregate.halstead.operators.total, 2);
+                });
+
+                test('first report aggregate has correct Halstead distinct operators', function () {
+                    assert.strictEqual(result.reports[0].aggregate.halstead.operators.distinct, 2);
+                });
+
+                test('first report aggregate has correct Halstead total operands', function () {
+                    assert.strictEqual(result.reports[0].aggregate.halstead.operands.total, 3);
+                });
+
+                test('first report aggregate has correct Halstead distinct operands', function () {
+                    assert.strictEqual(result.reports[0].aggregate.halstead.operands.distinct, 3);
+                });
+
+                test('first report aggregate has correct Halstead operator identifier length', function () {
+                    assert.lengthOf(
+                        result.reports[0].aggregate.halstead.operators.identifiers,
+                        result.reports[0].aggregate.halstead.operators.distinct
+                    );
+                });
+
+                test('first report aggregate has correct Halstead operand identifier length', function () {
+                    assert.lengthOf(
+                        result.reports[0].aggregate.halstead.operands.identifiers,
+                        result.reports[0].aggregate.halstead.operands.distinct
+                    );
+                });
+
+                test('first report aggregate has correct Halstead length', function () {
+                    assert.strictEqual(result.reports[0].aggregate.halstead.length, 5);
+                });
+
+                test('first report aggregate has correct Halstead vocabulary', function () {
+                    assert.strictEqual(result.reports[0].aggregate.halstead.vocabulary, 5);
+                });
+
+                test('first report aggregate has correct Halstead difficulty', function () {
+                    assert.strictEqual(result.reports[0].aggregate.halstead.difficulty, 1);
+                });
+
+                test('first report aggregate has correct Halstead volume', function () {
+                    assert.strictEqual(Math.round(result.reports[0].aggregate.halstead.volume), 12);
+                });
+
+                test('first report aggregate has correct Halstead effort', function () {
+                    assert.strictEqual(Math.round(result.reports[0].aggregate.halstead.effort), 12);
+                });
+
+                test('first report aggregate has correct Halstead bugs', function () {
+                    assert.strictEqual(Math.round(result.reports[0].aggregate.halstead.bugs), 0);
+                });
+
+                test('first report aggregate has correct Halstead time', function () {
+                    assert.strictEqual(Math.round(result.reports[0].aggregate.halstead.time), 1);
+                });
+
+                test('first report has correct path', function () {
+                    assert.strictEqual(result.reports[0].path, 'a');
+                });
+
+                test('second report maintainability index is correct', function () {
+                    assert.strictEqual(Math.round(result.reports[1].maintainability), 128);
+                });
+
+                test('second report first function has correct parameter count', function () {
+                    assert.strictEqual(result.reports[1].functions[0].params, 2);
+                });
+
+                test('second report second function has correct parameter count', function () {
+                    assert.strictEqual(result.reports[1].functions[1].params, 2);
+                });
+
+                test('second report aggregate has correct parameter count', function () {
+                    assert.strictEqual(result.reports[1].aggregate.params, 4);
+                });
+
+                test('second report mean parameter count is correct', function () {
+                    assert.strictEqual(result.reports[1].params, 2);
+                });
+
+                test('second report has correct path', function () {
+                    assert.strictEqual(result.reports[1].path, 'b');
+                });
+
+                test('first-order density is correct', function () {
+                    assert.strictEqual(result.firstOrderDensity, 0);
+                });
+
+                test('change cost is correct', function () {
+                    assert.strictEqual(result.changeCost, 50);
+                });
+
+                test('core size is correct', function () {
+                    assert.strictEqual(result.coreSize, 0);
+                });
+
+                test('mean per-function logical LOC is correct', function () {
+                    assert.strictEqual(result.loc, 4);
+                });
+
+                test('mean per-function cyclomatic complexity is correct', function () {
+                    assert.strictEqual(result.cyclomatic, 2);
+                });
+
+                test('mean per-function Halstead effort is correct', function () {
+                    assert.strictEqual(result.effort, 193.1614743092401);
+                });
+
+                test('mean per-function parameter count is correct', function () {
+                    assert.strictEqual(result.params, 1);
+                });
+
+                test('mean per-function maintainability index is correct', function () {
+                    assert.strictEqual(result.maintainability, 134.05623254229997);
+                });
             });
 
-            test('should not have aggregates if we call with skipCalculation', function() {
-                assert.deepEqual(Object.keys(reportsOnly), ['reports']);
+            suite('two modules with different options:', function() {
+                var modules = [], reportsOnly;
+                setup(function() {
+                    modules.push({
+                        ast: parser.parse('function foo (a, b) { if (a) { b(a); } else { a(b); } } function bar (c, d) { var i; for (i = 0; i < c.length; i += 1) { d += 1; } console.log(d); }', options),
+                        path: 'b'
+                    });
+                    modules.push({ ast: parser.parse('if (true) { "foo"; } else { "bar"; }', options), path: 'a' });
+                    reportsOnly = cr.analyse(modules, mozWalker, {skipCalculation: true});
+                });
+
+                test('should not have aggregates if we call with skipCalculation', function() {
+                    assert.deepEqual(Object.keys(reportsOnly), ['reports']);
+                });
+
+                test('should not have coreSize or visibilityMatrix if we call with noCoreSize', function() {
+                    var results = cr.analyse(modules, mozWalker, {noCoreSize: true});
+                    assert.notOk(results.coreSize);
+                    assert.notOk(results.visibilityMatrix);
+                    // make sure we still have a few things though
+                    assert.ok(results.adjacencyMatrix);
+                    assert.ok(results.loc);
+                });
+
+                test('should be able to run processResults', function() {
+                    var fullReport, calcReport;
+                    fullReport = cr.analyse(modules, mozWalker);
+                    calcReport = cr.processResults(reportsOnly);
+                    assert.deepEqual(calcReport, fullReport);
+                });
+
+                test('should be able to run processResults without calculating coreSize', function() {
+                    var results = cr.processResults(reportsOnly, true);
+                    assert.notOk(results.coreSize);
+                    assert.notOk(results.visibilityMatrix);
+                    // make sure we still have a few things though
+                    assert.ok(results.adjacencyMatrix);
+                    assert.ok(results.loc);
+                });
+
             });
 
-            test('should not have coreSize or visibilityMatrix if we call with noCoreSize', function() {
-                var results = cr.analyse(modules, mozWalker, {noCoreSize: true});
-                assert.notOk(results.coreSize);
-                assert.notOk(results.visibilityMatrix);
-                // make sure we still have a few things though
-                assert.ok(results.adjacencyMatrix);
-                assert.ok(results.loc);
+            suite('require directory (index.js)', function () {
+              setup(function () {
+                  this.path1 = '/b.js';
+                  this.path2 = '/mod/index.js';
+                  this.path3 = '/mod/a.js';
+
+                  var result = cr.analyse([
+                      { ast: parser.parse('require("./mod")',   options), path: this.path1 },
+                      { ast: parser.parse('require("./a")',     options), path: this.path2 },
+                      { ast: parser.parse('require("../b.js")', options), path: this.path3 }
+                  ], mozWalker);
+
+                  this.processResults = cr.processResults(result);
+              });
+
+              test('adjacency matrix is correct', function () {
+                  assert.strictEqual(this.processResults.reports[0].path, this.path1);
+                  assert.strictEqual(this.processResults.reports[1].path, this.path3);
+                  assert.strictEqual(this.processResults.reports[2].path, this.path2);
+
+                  assert.strictEqual(this.processResults.adjacencyMatrix.length, 3);
+
+                  assert.strictEqual(this.processResults.adjacencyMatrix[0][0], 0);
+                  assert.strictEqual(this.processResults.adjacencyMatrix[0][1], 0);
+                  assert.strictEqual(this.processResults.adjacencyMatrix[0][2], 1);
+
+                  assert.strictEqual(this.processResults.adjacencyMatrix[1][0], 1);
+                  assert.strictEqual(this.processResults.adjacencyMatrix[1][1], 0);
+                  assert.strictEqual(this.processResults.adjacencyMatrix[1][2], 0);
+
+                  assert.strictEqual(this.processResults.adjacencyMatrix[2][0], 0);
+                  assert.strictEqual(this.processResults.adjacencyMatrix[2][1], 1);
+                  assert.strictEqual(this.processResults.adjacencyMatrix[2][2], 0);
+              });
+
+              test('visibility matrix is correct', function () {
+                  assert.strictEqual(this.processResults.reports[0].path, this.path1);
+                  assert.strictEqual(this.processResults.reports[1].path, this.path3);
+                  assert.strictEqual(this.processResults.reports[2].path, this.path2);
+
+                  assert.strictEqual(this.processResults.visibilityMatrix.length, 3);
+
+                  assert.strictEqual(this.processResults.visibilityMatrix[0][0], 0);
+                  assert.strictEqual(this.processResults.visibilityMatrix[0][1], 1);
+                  assert.strictEqual(this.processResults.visibilityMatrix[0][2], 1);
+
+                  assert.strictEqual(this.processResults.visibilityMatrix[1][0], 1);
+                  assert.strictEqual(this.processResults.visibilityMatrix[1][1], 0);
+                  assert.strictEqual(this.processResults.visibilityMatrix[1][2], 1);
+
+                  assert.strictEqual(this.processResults.visibilityMatrix[2][0], 1);
+                  assert.strictEqual(this.processResults.visibilityMatrix[2][1], 1);
+                  assert.strictEqual(this.processResults.visibilityMatrix[2][2], 0);
+              });
             });
 
-            test('should be able to run processResults', function() {
-                var fullReport, calcReport;
-                fullReport = cr.analyse(modules, mozWalker);
-                calcReport = cr.processResults(reportsOnly);
-                assert.deepEqual(calcReport, fullReport);
+            suite('modules with dependencies:', function () {
+                var result;
+
+                setup(function () {
+                    result = cr.analyse([
+                        { ast: parser.parse('require("./a");"d";', options), path: '/d.js' },
+                        { ast: parser.parse('require("./b");"c";', options), path: '/a/c.js' },
+                        { ast: parser.parse('require("./c");"b";', options), path: '/a/b.js' },
+                        { ast: parser.parse('require("./a/b");require("./a/c");"a";', options), path: '/a.js' }
+                    ], mozWalker);
+                });
+
+                teardown(function () {
+                    result = undefined;
+                });
+
+                test('reports are in correct order', function () {
+                    assert.strictEqual(result.reports[0].path, '/a.js');
+                    assert.strictEqual(result.reports[1].path, '/d.js');
+                    assert.strictEqual(result.reports[2].path, '/a/b.js');
+                    assert.strictEqual(result.reports[3].path, '/a/c.js');
+                });
+
+                test('adjacency matrix is correct', function () {
+                    assert.lengthOf(result.adjacencyMatrix, 4);
+
+                    assert.lengthOf(result.adjacencyMatrix[0], 4);
+                    assert.strictEqual(result.adjacencyMatrix[0][0], 0);
+                    assert.strictEqual(result.adjacencyMatrix[0][1], 0);
+                    assert.strictEqual(result.adjacencyMatrix[0][2], 1);
+                    assert.strictEqual(result.adjacencyMatrix[0][3], 1);
+
+                    assert.lengthOf(result.adjacencyMatrix[1], 4);
+                    assert.strictEqual(result.adjacencyMatrix[1][0], 1);
+                    assert.strictEqual(result.adjacencyMatrix[1][1], 0);
+                    assert.strictEqual(result.adjacencyMatrix[1][2], 0);
+                    assert.strictEqual(result.adjacencyMatrix[1][3], 0);
+
+                    assert.lengthOf(result.adjacencyMatrix[2], 4);
+                    assert.strictEqual(result.adjacencyMatrix[2][0], 0);
+                    assert.strictEqual(result.adjacencyMatrix[2][1], 0);
+                    assert.strictEqual(result.adjacencyMatrix[2][2], 0);
+                    assert.strictEqual(result.adjacencyMatrix[2][3], 1);
+
+                    assert.lengthOf(result.adjacencyMatrix[3], 4);
+                    assert.strictEqual(result.adjacencyMatrix[3][0], 0);
+                    assert.strictEqual(result.adjacencyMatrix[3][1], 0);
+                    assert.strictEqual(result.adjacencyMatrix[3][2], 1);
+                    assert.strictEqual(result.adjacencyMatrix[3][3], 0);
+                });
+
+                test('first order density is correct', function () {
+                    assert.strictEqual(result.firstOrderDensity, 31.25);
+                });
+
+                test('change cost is correct', function () {
+                    assert.strictEqual(result.changeCost, 68.75);
+                });
+
+                test('core size is correct', function () {
+                    assert.strictEqual(result.coreSize, 0);
+                });
             });
 
-            test('should be able to run processResults without calculating coreSize', function() {
-                var results = cr.processResults(reportsOnly, true);
-                assert.notOk(results.coreSize);
-                assert.notOk(results.visibilityMatrix);
-                // make sure we still have a few things though
-                assert.ok(results.adjacencyMatrix);
-                assert.ok(results.loc);
-            });
+            suite('MacCormack, Rusnak & Baldwin example:', function () {
+                var result;
 
-        });
+                setup(function () {
+                    result = cr.analyse([
+                        { ast: parser.parse('"f";', options), path: '/a/c/f.js' },
+                        { ast: parser.parse('require("./f");"e";', options), path: '/a/c/e.js' },
+                        { ast: parser.parse('"d";', options), path: '/a/b/d.js' },
+                        { ast: parser.parse('require("./c/e");"c";', options), path: '/a/c.js' },
+                        { ast: parser.parse('require("./b/d");"b";', options), path: '/a/b.js' },
+                        { ast: parser.parse('require("./a/b");require("./a/c");"a";', options), path: '/a.js' }
+                    ], mozWalker);
+                });
 
-        suite('require directory (index.js)', function () {
-          setup(function () {
-              this.path1 = '/b.js';
-              this.path2 = '/mod/index.js';
-              this.path3 = '/mod/a.js';
+                teardown(function () {
+                    result = undefined;
+                });
 
-              var result = cr.analyse([
-                  { ast: espree.parse('require("./mod")',   { loc: true }), path: this.path1 },
-                  { ast: espree.parse('require("./a")',     { loc: true }), path: this.path2 },
-                  { ast: espree.parse('require("../b.js")', { loc: true }), path: this.path3 }
-              ], mozWalker);
+                test('reports are in correct order', function () {
+                    assert.strictEqual(result.reports[0].path, '/a.js');
+                    assert.strictEqual(result.reports[1].path, '/a/b.js');
+                    assert.strictEqual(result.reports[2].path, '/a/c.js');
+                    assert.strictEqual(result.reports[3].path, '/a/b/d.js');
+                    assert.strictEqual(result.reports[4].path, '/a/c/e.js');
+                    assert.strictEqual(result.reports[5].path, '/a/c/f.js');
+                });
 
-              this.processResults = cr.processResults(result);
-          });
+                test('adjacency matrix is correct', function () {
+                    assert.lengthOf(result.adjacencyMatrix, 6);
 
-          test('adjacency matrix is correct', function () {
-              assert.strictEqual(this.processResults.reports[0].path, this.path1);
-              assert.strictEqual(this.processResults.reports[1].path, this.path3);
-              assert.strictEqual(this.processResults.reports[2].path, this.path2);
+                    assert.lengthOf(result.adjacencyMatrix[0], 6);
+                    assert.strictEqual(result.adjacencyMatrix[0][0], 0);
+                    assert.strictEqual(result.adjacencyMatrix[0][1], 1);
+                    assert.strictEqual(result.adjacencyMatrix[0][2], 1);
+                    assert.strictEqual(result.adjacencyMatrix[0][3], 0);
+                    assert.strictEqual(result.adjacencyMatrix[0][4], 0);
+                    assert.strictEqual(result.adjacencyMatrix[0][5], 0);
 
-              assert.strictEqual(this.processResults.adjacencyMatrix.length, 3);
+                    assert.lengthOf(result.adjacencyMatrix[1], 6);
+                    assert.strictEqual(result.adjacencyMatrix[1][0], 0);
+                    assert.strictEqual(result.adjacencyMatrix[1][1], 0);
+                    assert.strictEqual(result.adjacencyMatrix[1][2], 0);
+                    assert.strictEqual(result.adjacencyMatrix[1][3], 1);
+                    assert.strictEqual(result.adjacencyMatrix[1][4], 0);
+                    assert.strictEqual(result.adjacencyMatrix[1][5], 0);
 
-              assert.strictEqual(this.processResults.adjacencyMatrix[0][0], 0);
-              assert.strictEqual(this.processResults.adjacencyMatrix[0][1], 0);
-              assert.strictEqual(this.processResults.adjacencyMatrix[0][2], 1);
+                    assert.lengthOf(result.adjacencyMatrix[2], 6);
+                    assert.strictEqual(result.adjacencyMatrix[2][0], 0);
+                    assert.strictEqual(result.adjacencyMatrix[2][1], 0);
+                    assert.strictEqual(result.adjacencyMatrix[2][2], 0);
+                    assert.strictEqual(result.adjacencyMatrix[2][3], 0);
+                    assert.strictEqual(result.adjacencyMatrix[2][4], 1);
+                    assert.strictEqual(result.adjacencyMatrix[2][5], 0);
 
-              assert.strictEqual(this.processResults.adjacencyMatrix[1][0], 1);
-              assert.strictEqual(this.processResults.adjacencyMatrix[1][1], 0);
-              assert.strictEqual(this.processResults.adjacencyMatrix[1][2], 0);
+                    assert.lengthOf(result.adjacencyMatrix[3], 6);
+                    assert.strictEqual(result.adjacencyMatrix[3][0], 0);
+                    assert.strictEqual(result.adjacencyMatrix[3][1], 0);
+                    assert.strictEqual(result.adjacencyMatrix[3][2], 0);
+                    assert.strictEqual(result.adjacencyMatrix[3][3], 0);
+                    assert.strictEqual(result.adjacencyMatrix[3][4], 0);
+                    assert.strictEqual(result.adjacencyMatrix[3][5], 0);
 
-              assert.strictEqual(this.processResults.adjacencyMatrix[2][0], 0);
-              assert.strictEqual(this.processResults.adjacencyMatrix[2][1], 1);
-              assert.strictEqual(this.processResults.adjacencyMatrix[2][2], 0);
-          });
+                    assert.lengthOf(result.adjacencyMatrix[4], 6);
+                    assert.strictEqual(result.adjacencyMatrix[4][0], 0);
+                    assert.strictEqual(result.adjacencyMatrix[4][1], 0);
+                    assert.strictEqual(result.adjacencyMatrix[4][2], 0);
+                    assert.strictEqual(result.adjacencyMatrix[4][3], 0);
+                    assert.strictEqual(result.adjacencyMatrix[4][4], 0);
+                    assert.strictEqual(result.adjacencyMatrix[4][5], 1);
 
-          test('visibility matrix is correct', function () {
-              assert.strictEqual(this.processResults.reports[0].path, this.path1);
-              assert.strictEqual(this.processResults.reports[1].path, this.path3);
-              assert.strictEqual(this.processResults.reports[2].path, this.path2);
+                    assert.lengthOf(result.adjacencyMatrix[5], 6);
+                    assert.strictEqual(result.adjacencyMatrix[5][0], 0);
+                    assert.strictEqual(result.adjacencyMatrix[5][1], 0);
+                    assert.strictEqual(result.adjacencyMatrix[5][2], 0);
+                    assert.strictEqual(result.adjacencyMatrix[5][3], 0);
+                    assert.strictEqual(result.adjacencyMatrix[5][4], 0);
+                    assert.strictEqual(result.adjacencyMatrix[5][5], 0);
+                });
 
-              assert.strictEqual(this.processResults.visibilityMatrix.length, 3);
+                test('first order density is correct', function () {
+                    assert.isTrue(result.firstOrderDensity > 13.88);
+                    assert.isTrue(result.firstOrderDensity < 13.89);
+                });
 
-              assert.strictEqual(this.processResults.visibilityMatrix[0][0], 0);
-              assert.strictEqual(this.processResults.visibilityMatrix[0][1], 1);
-              assert.strictEqual(this.processResults.visibilityMatrix[0][2], 1);
+                test('change cost is correct', function () {
+                    assert.isTrue(result.changeCost > 41.66);
+                    assert.isTrue(result.changeCost < 41.67);
+                });
 
-              assert.strictEqual(this.processResults.visibilityMatrix[1][0], 1);
-              assert.strictEqual(this.processResults.visibilityMatrix[1][1], 0);
-              assert.strictEqual(this.processResults.visibilityMatrix[1][2], 1);
-
-              assert.strictEqual(this.processResults.visibilityMatrix[2][0], 1);
-              assert.strictEqual(this.processResults.visibilityMatrix[2][1], 1);
-              assert.strictEqual(this.processResults.visibilityMatrix[2][2], 0);
-          });
-        });
-
-        suite('modules with dependencies:', function () {
-            var result;
-
-            setup(function () {
-                result = cr.analyse([
-                    { ast: espree.parse('require("./a");"d";', { loc: true }), path: '/d.js' },
-                    { ast: espree.parse('require("./b");"c";', { loc: true }), path: '/a/c.js' },
-                    { ast: espree.parse('require("./c");"b";', { loc: true }), path: '/a/b.js' },
-                    { ast: espree.parse('require("./a/b");require("./a/c");"a";', { loc: true }), path: '/a.js' }
-                ], mozWalker);
-            });
-
-            teardown(function () {
-                result = undefined;
-            });
-
-            test('reports are in correct order', function () {
-                assert.strictEqual(result.reports[0].path, '/a.js');
-                assert.strictEqual(result.reports[1].path, '/d.js');
-                assert.strictEqual(result.reports[2].path, '/a/b.js');
-                assert.strictEqual(result.reports[3].path, '/a/c.js');
-            });
-
-            test('adjacency matrix is correct', function () {
-                assert.lengthOf(result.adjacencyMatrix, 4);
-
-                assert.lengthOf(result.adjacencyMatrix[0], 4);
-                assert.strictEqual(result.adjacencyMatrix[0][0], 0);
-                assert.strictEqual(result.adjacencyMatrix[0][1], 0);
-                assert.strictEqual(result.adjacencyMatrix[0][2], 1);
-                assert.strictEqual(result.adjacencyMatrix[0][3], 1);
-
-                assert.lengthOf(result.adjacencyMatrix[1], 4);
-                assert.strictEqual(result.adjacencyMatrix[1][0], 1);
-                assert.strictEqual(result.adjacencyMatrix[1][1], 0);
-                assert.strictEqual(result.adjacencyMatrix[1][2], 0);
-                assert.strictEqual(result.adjacencyMatrix[1][3], 0);
-
-                assert.lengthOf(result.adjacencyMatrix[2], 4);
-                assert.strictEqual(result.adjacencyMatrix[2][0], 0);
-                assert.strictEqual(result.adjacencyMatrix[2][1], 0);
-                assert.strictEqual(result.adjacencyMatrix[2][2], 0);
-                assert.strictEqual(result.adjacencyMatrix[2][3], 1);
-
-                assert.lengthOf(result.adjacencyMatrix[3], 4);
-                assert.strictEqual(result.adjacencyMatrix[3][0], 0);
-                assert.strictEqual(result.adjacencyMatrix[3][1], 0);
-                assert.strictEqual(result.adjacencyMatrix[3][2], 1);
-                assert.strictEqual(result.adjacencyMatrix[3][3], 0);
-            });
-
-            test('first order density is correct', function () {
-                assert.strictEqual(result.firstOrderDensity, 31.25);
-            });
-
-            test('change cost is correct', function () {
-                assert.strictEqual(result.changeCost, 68.75);
-            });
-
-            test('core size is correct', function () {
-                assert.strictEqual(result.coreSize, 0);
-            });
-        });
-
-        suite('MacCormack, Rusnak & Baldwin example:', function () {
-            var result;
-
-            setup(function () {
-                result = cr.analyse([
-                    { ast: espree.parse('"f";', { loc: true }), path: '/a/c/f.js' },
-                    { ast: espree.parse('require("./f");"e";', { loc: true }), path: '/a/c/e.js' },
-                    { ast: espree.parse('"d";', { loc: true }), path: '/a/b/d.js' },
-                    { ast: espree.parse('require("./c/e");"c";', { loc: true }), path: '/a/c.js' },
-                    { ast: espree.parse('require("./b/d");"b";', { loc: true }), path: '/a/b.js' },
-                    { ast: espree.parse('require("./a/b");require("./a/c");"a";', { loc: true }), path: '/a.js' }
-                ], mozWalker);
-            });
-
-            teardown(function () {
-                result = undefined;
-            });
-
-            test('reports are in correct order', function () {
-                assert.strictEqual(result.reports[0].path, '/a.js');
-                assert.strictEqual(result.reports[1].path, '/a/b.js');
-                assert.strictEqual(result.reports[2].path, '/a/c.js');
-                assert.strictEqual(result.reports[3].path, '/a/b/d.js');
-                assert.strictEqual(result.reports[4].path, '/a/c/e.js');
-                assert.strictEqual(result.reports[5].path, '/a/c/f.js');
-            });
-
-            test('adjacency matrix is correct', function () {
-                assert.lengthOf(result.adjacencyMatrix, 6);
-
-                assert.lengthOf(result.adjacencyMatrix[0], 6);
-                assert.strictEqual(result.adjacencyMatrix[0][0], 0);
-                assert.strictEqual(result.adjacencyMatrix[0][1], 1);
-                assert.strictEqual(result.adjacencyMatrix[0][2], 1);
-                assert.strictEqual(result.adjacencyMatrix[0][3], 0);
-                assert.strictEqual(result.adjacencyMatrix[0][4], 0);
-                assert.strictEqual(result.adjacencyMatrix[0][5], 0);
-
-                assert.lengthOf(result.adjacencyMatrix[1], 6);
-                assert.strictEqual(result.adjacencyMatrix[1][0], 0);
-                assert.strictEqual(result.adjacencyMatrix[1][1], 0);
-                assert.strictEqual(result.adjacencyMatrix[1][2], 0);
-                assert.strictEqual(result.adjacencyMatrix[1][3], 1);
-                assert.strictEqual(result.adjacencyMatrix[1][4], 0);
-                assert.strictEqual(result.adjacencyMatrix[1][5], 0);
-
-                assert.lengthOf(result.adjacencyMatrix[2], 6);
-                assert.strictEqual(result.adjacencyMatrix[2][0], 0);
-                assert.strictEqual(result.adjacencyMatrix[2][1], 0);
-                assert.strictEqual(result.adjacencyMatrix[2][2], 0);
-                assert.strictEqual(result.adjacencyMatrix[2][3], 0);
-                assert.strictEqual(result.adjacencyMatrix[2][4], 1);
-                assert.strictEqual(result.adjacencyMatrix[2][5], 0);
-
-                assert.lengthOf(result.adjacencyMatrix[3], 6);
-                assert.strictEqual(result.adjacencyMatrix[3][0], 0);
-                assert.strictEqual(result.adjacencyMatrix[3][1], 0);
-                assert.strictEqual(result.adjacencyMatrix[3][2], 0);
-                assert.strictEqual(result.adjacencyMatrix[3][3], 0);
-                assert.strictEqual(result.adjacencyMatrix[3][4], 0);
-                assert.strictEqual(result.adjacencyMatrix[3][5], 0);
-
-                assert.lengthOf(result.adjacencyMatrix[4], 6);
-                assert.strictEqual(result.adjacencyMatrix[4][0], 0);
-                assert.strictEqual(result.adjacencyMatrix[4][1], 0);
-                assert.strictEqual(result.adjacencyMatrix[4][2], 0);
-                assert.strictEqual(result.adjacencyMatrix[4][3], 0);
-                assert.strictEqual(result.adjacencyMatrix[4][4], 0);
-                assert.strictEqual(result.adjacencyMatrix[4][5], 1);
-
-                assert.lengthOf(result.adjacencyMatrix[5], 6);
-                assert.strictEqual(result.adjacencyMatrix[5][0], 0);
-                assert.strictEqual(result.adjacencyMatrix[5][1], 0);
-                assert.strictEqual(result.adjacencyMatrix[5][2], 0);
-                assert.strictEqual(result.adjacencyMatrix[5][3], 0);
-                assert.strictEqual(result.adjacencyMatrix[5][4], 0);
-                assert.strictEqual(result.adjacencyMatrix[5][5], 0);
-            });
-
-            test('first order density is correct', function () {
-                assert.isTrue(result.firstOrderDensity > 13.88);
-                assert.isTrue(result.firstOrderDensity < 13.89);
-            });
-
-            test('change cost is correct', function () {
-                assert.isTrue(result.changeCost > 41.66);
-                assert.isTrue(result.changeCost < 41.67);
-            });
-
-            test('core size is correct', function () {
-                assert.isTrue(result.coreSize > 16.66);
-                assert.isTrue(result.coreSize < 16.67);
+                test('core size is correct', function () {
+                    assert.isTrue(result.coreSize > 16.66);
+                    assert.isTrue(result.coreSize < 16.67);
+                });
             });
         });
     });

--- a/test/walker.js
+++ b/test/walker.js
@@ -2,293 +2,293 @@
 
 var assert = require('chai').assert;
 var sinon = require('sinon');
-var espree = require('espree');
+var parsers = require('./helpers/parsers');
 var walker = require('../src/walker');
-var parserOptions = require('../src/config').parserOptions;
 
 // List of test cases taken directly from the ESTree
 // spec (https://github.com/estree/estree)
-suite('AST Walker', function () {
+parsers.forEach(function (parserName, parser, options) {
+    suite('AST Walker', function () {
 
-    setup(function () {
-        this.callbacks = {
-            processNode: sinon.stub(),
-            createScope: sinon.stub(),
-            popScope: sinon.stub()
-        };
+        setup(function () {
+            this.callbacks = {
+                processNode: sinon.stub(),
+                createScope: sinon.stub(),
+                popScope: sinon.stub()
+            };
 
-        this.walk = function parse (code) {
-            var tree = espree.parse(code, parserOptions);
-            walker.walk(tree, {}, this.callbacks);
-        };
+            this.walk = function parse (code) {
+                var tree = parser.parse(code, options);
+                walker.walk(tree, {}, this.callbacks);
+            };
+        });
+
+
+        suite('Unsupported Syntax', function () {
+            test('empty statement', function () {
+                this.walk(';');
+                assert.strictEqual(this.callbacks.processNode.callCount, 0);
+            });
+
+            test('labeled statement', function () {
+                this.walk('foo: a;');
+                assert.strictEqual(this.callbacks.processNode.callCount, 0);
+            });
+        });
+
+
+        suite('Statements', function () {
+            test('empty block statement', function () {
+                this.walk('{}');
+
+                var blockNode = this.callbacks.processNode.firstCall.args[0];
+                assert.strictEqual(blockNode.type, 'BlockStatement');
+                assert.strictEqual(blockNode.body.length, 0);
+
+                assert.strictEqual(this.callbacks.createScope.callCount, 0);
+                assert.strictEqual(this.callbacks.popScope.callCount, 0);
+            });
+
+            test('expression statement', function () {
+                this.walk('a');
+
+                var statement = this.callbacks.processNode.firstCall.args[0];
+                var expression = this.callbacks.processNode.secondCall.args[0];
+                assert.strictEqual(statement.type, 'ExpressionStatement');
+                assert.strictEqual(statement.expression, expression);
+                assert.strictEqual(this.callbacks.createScope.callCount, 0);
+                assert.strictEqual(this.callbacks.popScope.callCount, 0);
+            });
+
+            test('if statement', function () {
+                this.walk('if (true) { true; } else { false; }');
+
+                var statement = this.callbacks.processNode.firstCall.args[0];
+                assert.strictEqual(statement.type, 'IfStatement');
+                assert.strictEqual(statement.test.type, 'Literal');
+                assert.strictEqual(statement.test.value, true);
+                assert.strictEqual(statement.consequent.body[0].expression.value, true);
+                assert.strictEqual(statement.alternate.body[0].expression.value, false);
+            });
+
+
+            test('break statement');
+            test('continue statement');
+            test('with statement');
+            test('switch statement');
+            test('return statement');
+            test('throw statement');
+            test('try statement');
+            test('while statement');
+            test('do-while statement');
+            test('for statement');
+            test('for-in statement');
+            test('for-of statement');
+            test('debugger statement');
+        });
+
+
+        suite('Declarations', function () {
+            test('function declaration', function () {
+                this.walk('function foo() {}');
+
+                var declaration = this.callbacks.processNode.firstCall.args[0];
+                assert.strictEqual(declaration.type, 'FunctionDeclaration');
+                assert.strictEqual(declaration.id.name, 'foo');
+                assert.strictEqual(declaration.id.type, 'Identifier');
+                assert.strictEqual(declaration.params.length, 0);
+                assert.strictEqual(declaration.body.type, 'BlockStatement');
+                assert.strictEqual(declaration.body.body.length, 0);
+            });
+
+            test('generator function declaration', function () {
+                this.walk('function* foo() {}');
+
+                var declaration = this.callbacks.processNode.firstCall.args[0];
+                assert.strictEqual(declaration.type, 'FunctionDeclaration');
+                assert.strictEqual(declaration.id.name, 'foo');
+                assert.strictEqual(declaration.id.type, 'Identifier');
+                assert.strictEqual(declaration.generator, true);
+                assert.strictEqual(declaration.params.length, 0);
+                assert.strictEqual(declaration.body.type, 'BlockStatement');
+                assert.strictEqual(declaration.body.body.length, 0);
+            });
+
+            test('var declaration', function () {
+                this.walk('var a = 1');
+
+                var statement = this.callbacks.processNode.firstCall.args[0];
+                assert.strictEqual(statement.type, 'VariableDeclaration');
+                assert.strictEqual(statement.kind, 'var');
+                assert.strictEqual(statement.declarations.length, 1);
+            });
+
+            test('let declaration', function () {
+                this.walk('let a = 1');
+
+                var statement = this.callbacks.processNode.firstCall.args[0];
+                assert.strictEqual(statement.type, 'VariableDeclaration');
+                assert.strictEqual(statement.kind, 'let');
+                assert.strictEqual(statement.declarations.length, 1);
+            });
+
+            test('const declaration', function () {
+                this.walk('const a = 1');
+
+                var statement = this.callbacks.processNode.firstCall.args[0];
+                assert.strictEqual(statement.type, 'VariableDeclaration');
+                assert.strictEqual(statement.kind, 'const');
+                assert.strictEqual(statement.declarations.length, 1);
+            });
+
+            test('var declarator', function () {
+                this.walk('var a = 1');
+
+                var statement = this.callbacks.processNode.firstCall.args[0];
+                var declarator = this.callbacks.processNode.secondCall.args[0];
+                assert.strictEqual(statement.declarations[0], declarator);
+                assert.strictEqual(declarator.id.type, 'Identifier');
+                assert.strictEqual(declarator.id.name, 'a');
+            });
+
+            test('let declarator', function () {
+                this.walk('let a = 1');
+
+                var statement = this.callbacks.processNode.firstCall.args[0];
+                var declarator = this.callbacks.processNode.secondCall.args[0];
+                assert.strictEqual(statement.declarations[0], declarator);
+                assert.strictEqual(declarator.id.type, 'Identifier');
+                assert.strictEqual(declarator.id.name, 'a');
+            });
+
+            test('const declarator', function () {
+                this.walk('const a = 1');
+
+                var statement = this.callbacks.processNode.firstCall.args[0];
+                var declarator = this.callbacks.processNode.secondCall.args[0];
+                assert.strictEqual(statement.declarations[0], declarator);
+                assert.strictEqual(declarator.id.type, 'Identifier');
+                assert.strictEqual(declarator.id.name, 'a');
+            });
+        });
+
+        /* Expressions */
+        suite('Expressions', function () {
+            test('this expression', function () {
+                this.walk('this');
+
+                var expression = this.callbacks.processNode.firstCall.args[0].expression;
+                assert.strictEqual(expression.type, 'ThisExpression');
+            });
+
+            test('empty array expression', function () {
+                this.walk('[]');
+                var expression = this.callbacks.processNode.firstCall.args[0].expression;
+                assert.strictEqual(expression.type, 'ArrayExpression');
+                assert.strictEqual(expression.elements.length, 0);
+            });
+
+            test('array expression', function () {
+                this.walk('[ 1, 2 ]');
+                var expression = this.callbacks.processNode.firstCall.args[0].expression;
+                assert.strictEqual(expression.type, 'ArrayExpression');
+                assert.strictEqual(expression.elements.length, 2);
+                assert.strictEqual(expression.elements[0].value, 1);
+                assert.strictEqual(expression.elements[1].value, 2);
+            });
+
+            test('object expression');
+            test('property expression');
+
+            test('function expression', function () {
+                this.walk('(function foo() {})');
+                var expression = this.callbacks.processNode.firstCall.args[0].expression;
+                assert.strictEqual(expression.type, 'FunctionExpression');
+                assert.strictEqual(expression.id.name, 'foo');
+                assert.strictEqual(expression.generator, false);
+            });
+
+            test('generator function expression', function () {
+                this.walk('(function* foo() {})');
+                var expression = this.callbacks.processNode.firstCall.args[0].expression;
+                assert.strictEqual(expression.type, 'FunctionExpression');
+                assert.strictEqual(expression.id.name, 'foo');
+                assert.strictEqual(expression.generator, true);
+            });
+
+            test('sequence expression');
+            test('unary expression');
+            test('binary expression');
+            test('assignment expression');
+            test('update expression');
+
+            test('logical expression: &&', function () {
+                this.walk('1 && 1');
+                var expression = this.callbacks.processNode.firstCall.args[0].expression;
+                assert.strictEqual(expression.type, 'LogicalExpression');
+                assert.strictEqual(expression.operator, '&&');
+            });
+
+            test('logical expression: ||', function () {
+                this.walk('1 || 1');
+                var expression = this.callbacks.processNode.firstCall.args[0].expression;
+                assert.strictEqual(expression.type, 'LogicalExpression');
+                assert.strictEqual(expression.operator, '||');
+            });
+
+            test('conditional expression');
+            test('call expression');
+            test('new expression');
+            test('member expression');
+            test('super expression');
+            test('arrow function expression');
+            test('yield expression');
+            test('tagged template expression');
+        });
+
+        suite('Classes', function () {
+            test('class');
+            test('class body');
+            test('method definition');
+            test('class declaration');
+            test('meta property');
+        });
+
+        suite('Modules', function () {
+            test('module declaration');
+            test('module specifier');
+            test('import declaration');
+            test('import specifier');
+            test('import default specifier');
+            test('import namespace specifier');
+            test('export named declaration');
+            test('export specifier');
+            test('export default declaration');
+            test('export all declaration');
+        });
+
+        suite('Clauses', function () {
+            test('switchcase');
+            test('case clause');
+        });
+
+        suite('Miscellaneous', function () {
+            test('identifier');
+            test('literal');
+            test('regexp literal');
+            test('unary operator');
+            test('binary operator');
+            test('logical operator');
+            test('assignment operator');
+            test('update operator');
+            test('spread element');
+            test('template literal');
+            test('template element');
+            test('object pattern');
+            test('assignment property');
+            test('assignment pattern');
+            test('array pattern');
+            test('rest element');
+        });
     });
-
-
-    suite('Unsupported Syntax', function () {
-        test('empty statement', function () {
-            this.walk(';');
-            assert.strictEqual(this.callbacks.processNode.callCount, 0);
-        });
-
-        test('labeled statement', function () {
-            this.walk('foo: a;');
-            assert.strictEqual(this.callbacks.processNode.callCount, 0);
-        });
-    });
-
-
-    suite('Statements', function () {
-        test('empty block statement', function () {
-            this.walk('{}');
-
-            var blockNode = this.callbacks.processNode.firstCall.args[0];
-            assert.strictEqual(blockNode.type, 'BlockStatement');
-            assert.strictEqual(blockNode.body.length, 0);
-
-            assert.strictEqual(this.callbacks.createScope.callCount, 0);
-            assert.strictEqual(this.callbacks.popScope.callCount, 0);
-        });
-
-        test('expression statement', function () {
-            this.walk('a');
-
-            var statement = this.callbacks.processNode.firstCall.args[0];
-            var expression = this.callbacks.processNode.secondCall.args[0];
-            assert.strictEqual(statement.type, 'ExpressionStatement');
-            assert.strictEqual(statement.expression, expression);
-            assert.strictEqual(this.callbacks.createScope.callCount, 0);
-            assert.strictEqual(this.callbacks.popScope.callCount, 0);
-        });
-
-        test('if statement', function () {
-            this.walk('if (true) { true; } else { false; }');
-
-            var statement = this.callbacks.processNode.firstCall.args[0];
-            assert.strictEqual(statement.type, 'IfStatement');
-            assert.strictEqual(statement.test.type, 'Literal');
-            assert.strictEqual(statement.test.value, true);
-            assert.strictEqual(statement.consequent.body[0].expression.value, true);
-            assert.strictEqual(statement.alternate.body[0].expression.value, false);
-        });
-
-
-        test('break statement');
-        test('continue statement');
-        test('with statement');
-        test('switch statement');
-        test('return statement');
-        test('throw statement');
-        test('try statement');
-        test('while statement');
-        test('do-while statement');
-        test('for statement');
-        test('for-in statement');
-        test('for-of statement');
-        test('debugger statement');
-    });
-
-
-    suite('Declarations', function () {
-        test('function declaration', function () {
-            this.walk('function foo() {}');
-
-            var declaration = this.callbacks.processNode.firstCall.args[0];
-            assert.strictEqual(declaration.type, 'FunctionDeclaration');
-            assert.strictEqual(declaration.id.name, 'foo');
-            assert.strictEqual(declaration.id.type, 'Identifier');
-            assert.strictEqual(declaration.params.length, 0);
-            assert.strictEqual(declaration.body.type, 'BlockStatement');
-            assert.strictEqual(declaration.body.body.length, 0);
-        });
-
-        test('generator function declaration', function () {
-            this.walk('function* foo() {}');
-
-            var declaration = this.callbacks.processNode.firstCall.args[0];
-            assert.strictEqual(declaration.type, 'FunctionDeclaration');
-            assert.strictEqual(declaration.id.name, 'foo');
-            assert.strictEqual(declaration.id.type, 'Identifier');
-            assert.strictEqual(declaration.generator, true);
-            assert.strictEqual(declaration.params.length, 0);
-            assert.strictEqual(declaration.body.type, 'BlockStatement');
-            assert.strictEqual(declaration.body.body.length, 0);
-        });
-
-        test('var declaration', function () {
-            this.walk('var a = 1');
-
-            var statement = this.callbacks.processNode.firstCall.args[0];
-            assert.strictEqual(statement.type, 'VariableDeclaration');
-            assert.strictEqual(statement.kind, 'var');
-            assert.strictEqual(statement.declarations.length, 1);
-        });
-
-        test('let declaration', function () {
-            this.walk('let a = 1');
-
-            var statement = this.callbacks.processNode.firstCall.args[0];
-            assert.strictEqual(statement.type, 'VariableDeclaration');
-            assert.strictEqual(statement.kind, 'let');
-            assert.strictEqual(statement.declarations.length, 1);
-        });
-
-        test('const declaration', function () {
-            this.walk('const a = 1');
-
-            var statement = this.callbacks.processNode.firstCall.args[0];
-            assert.strictEqual(statement.type, 'VariableDeclaration');
-            assert.strictEqual(statement.kind, 'const');
-            assert.strictEqual(statement.declarations.length, 1);
-        });
-
-        test('var declarator', function () {
-            this.walk('var a = 1');
-
-            var statement = this.callbacks.processNode.firstCall.args[0];
-            var declarator = this.callbacks.processNode.secondCall.args[0];
-            assert.strictEqual(statement.declarations[0], declarator);
-            assert.strictEqual(declarator.id.type, 'Identifier');
-            assert.strictEqual(declarator.id.name, 'a');
-        });
-
-        test('let declarator', function () {
-            this.walk('let a = 1');
-
-            var statement = this.callbacks.processNode.firstCall.args[0];
-            var declarator = this.callbacks.processNode.secondCall.args[0];
-            assert.strictEqual(statement.declarations[0], declarator);
-            assert.strictEqual(declarator.id.type, 'Identifier');
-            assert.strictEqual(declarator.id.name, 'a');
-        });
-
-        test('const declarator', function () {
-            this.walk('const a = 1');
-
-            var statement = this.callbacks.processNode.firstCall.args[0];
-            var declarator = this.callbacks.processNode.secondCall.args[0];
-            assert.strictEqual(statement.declarations[0], declarator);
-            assert.strictEqual(declarator.id.type, 'Identifier');
-            assert.strictEqual(declarator.id.name, 'a');
-        });
-    });
-
-    /* Expressions */
-    suite('Expressions', function () {
-        test('this expression', function () {
-            this.walk('this');
-
-            var expression = this.callbacks.processNode.firstCall.args[0].expression;
-            assert.strictEqual(expression.type, 'ThisExpression');
-        });
-
-        test('empty array expression', function () {
-            this.walk('[]');
-            var expression = this.callbacks.processNode.firstCall.args[0].expression;
-            assert.strictEqual(expression.type, 'ArrayExpression');
-            assert.strictEqual(expression.elements.length, 0);
-        });
-
-        test('array expression', function () {
-            this.walk('[ 1, 2 ]');
-            var expression = this.callbacks.processNode.firstCall.args[0].expression;
-            assert.strictEqual(expression.type, 'ArrayExpression');
-            assert.strictEqual(expression.elements.length, 2);
-            assert.strictEqual(expression.elements[0].value, 1);
-            assert.strictEqual(expression.elements[1].value, 2);
-        });
-
-        test('object expression');
-        test('property expression');
-
-        test('function expression', function () {
-            this.walk('(function foo() {})');
-            var expression = this.callbacks.processNode.firstCall.args[0].expression;
-            assert.strictEqual(expression.type, 'FunctionExpression');
-            assert.strictEqual(expression.id.name, 'foo');
-            assert.strictEqual(expression.generator, false);
-        });
-
-        test('generator function expression', function () {
-            this.walk('(function* foo() {})');
-            var expression = this.callbacks.processNode.firstCall.args[0].expression;
-            assert.strictEqual(expression.type, 'FunctionExpression');
-            assert.strictEqual(expression.id.name, 'foo');
-            assert.strictEqual(expression.generator, true);
-        });
-
-        test('sequence expression');
-        test('unary expression');
-        test('binary expression');
-        test('assignment expression');
-        test('update expression');
-
-        test('logical expression: &&', function () {
-            this.walk('1 && 1');
-            var expression = this.callbacks.processNode.firstCall.args[0].expression;
-            assert.strictEqual(expression.type, 'LogicalExpression');
-            assert.strictEqual(expression.operator, '&&');
-        });
-
-        test('logical expression: ||', function () {
-            this.walk('1 || 1');
-            var expression = this.callbacks.processNode.firstCall.args[0].expression;
-            assert.strictEqual(expression.type, 'LogicalExpression');
-            assert.strictEqual(expression.operator, '||');
-        });
-
-        test('conditional expression');
-        test('call expression');
-        test('new expression');
-        test('member expression');
-        test('super expression');
-        test('arrow function expression');
-        test('yield expression');
-        test('tagged template expression');
-    });
-
-    suite('Classes', function () {
-        test('class');
-        test('class body');
-        test('method definition');
-        test('class declaration');
-        test('meta property');
-    });
-
-    suite('Modules', function () {
-        test('module declaration');
-        test('module specifier');
-        test('import declaration');
-        test('import specifier');
-        test('import default specifier');
-        test('import namespace specifier');
-        test('export named declaration');
-        test('export specifier');
-        test('export default declaration');
-        test('export all declaration');
-    });
-
-    suite('Clauses', function () {
-        test('switchcase');
-        test('case clause');
-    });
-
-    suite('Miscellaneous', function () {
-        test('identifier');
-        test('literal');
-        test('regexp literal');
-        test('unary operator');
-        test('binary operator');
-        test('logical operator');
-        test('assignment operator');
-        test('update operator');
-        test('spread element');
-        test('template literal');
-        test('template element');
-        test('object pattern');
-        test('assignment property');
-        test('assignment pattern');
-        test('array pattern');
-        test('rest element');
-    });
-
 });


### PR DESCRIPTION
This commit adds support in the unit tests for running against multiple
parsers. This brings integration issues and required options into a
sharper focus. It will also help highlight inconsistencies across each
parser.