### PR TITLE
Deprecate older node versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,5 @@ language: node_js
 sudo: false
 node_js:
   - "node"
-  - "iojs"
-  - "6.0"
-  - "5.0"
-  - "4.2"
-  - "0.12"
-  - "0.10"
+  - "6"
+  - "4"

--- a/src/config.js
+++ b/src/config.js
@@ -1,4 +1,5 @@
 'use strict'
+
 module.exports.parserOptions = {
   ecmaVersion: 7,
   loc: true

--- a/src/core.js
+++ b/src/core.js
@@ -1,10 +1,8 @@
-/**
- * Code complexity reporting for Mozilla-format abstract syntax trees.
- */
-/* globals exports, require */
 'use strict'
-var projectHandler = require('./project')
-var moduleHandler = require('./module')
+
+const projectHandler = require('./project')
+const moduleHandler = require('./module')
+
 module.exports.analyse = analyse
 module.exports.processResults = processResults
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,17 +1,19 @@
-/* globals require, exports */
 'use strict'
-var _assign = require('lodash.assign')
-var _negate = require('lodash.negate')
-var _isNil = require('lodash.isnil')
-var espree = require('espree')
-var walker = require('./walker')
-var core = require('./core')
-var debug = require('debug')('escomplex')
-var defaultParserOptions = require('./config').parserOptions
-module.exports.analyse = function analyse (source, options, parsing) {
+
+const _assign = require('lodash.assign')
+const _negate = require('lodash.negate')
+const _isNil = require('lodash.isnil')
+const espree = require('espree')
+const walker = require('./walker')
+const core = require('./core')
+const debug = require('debug')('escomplex')
+const defaultParserOptions = require('./config').parserOptions
+
+module.exports.analyse = (source, options, parsing) => {
   var ast
   var parser = defaultParser
-  var parserOptions = defaultParserOptions
+  const parserOptions = defaultParserOptions
+
   if (typeof parsing === 'function') {
     parser = parsing
     debug('Custom parse function')
@@ -40,7 +42,7 @@ function defaultParser (source, parserOptions) {
 }
 
 function parseProject (sources, parser, parserOptions, options) {
-  return sources.map(function parseProjectModule (source) {
+  return sources.map(source => {
     try {
       return {
         ast: parser(source.code, parserOptions),
@@ -53,5 +55,6 @@ function parseProject (sources, parser, parserOptions, options) {
       error.message = source.path + ': ' + error.message
       throw error
     }
-  }).filter(_negate(_isNil))
+  })
+  .filter(_negate(_isNil))
 }

--- a/src/module.js
+++ b/src/module.js
@@ -1,14 +1,11 @@
-/* globals exports, require */
 'use strict'
-var _isObject = require('lodash.isobject')
-var _isFunction = require('lodash.isfunction')
-var _isNumber = require('lodash.isnumber')
-var assert = require('assert')
-var report
-var debug = require('debug')('escomplex:module')
-exports.analyse = analyse
 
-var defaultSettings = {
+const _isObject = require('lodash.isobject')
+const _isFunction = require('lodash.isfunction')
+const _isNumber = require('lodash.isnumber')
+const assert = require('assert')
+const debug = require('debug')('escomplex:module')
+const defaultSettings = {
   forin: false,
   logicalor: true,
   newmi: false,
@@ -16,12 +13,16 @@ var defaultSettings = {
   trycatch: false
 }
 
+module.exports.analyse = analyse
+
+var report
+
 function analyse (ast, walker, options) {
   // TODO: Asynchronise
   var settings
   var currentReport
   var clearDependencies = true
-  var scopeStack = []
+  const scopeStack = []
 
   assert(_isObject(ast), 'Invalid syntax tree')
   assert(_isObject(walker), 'Invalid walker')
@@ -81,7 +82,7 @@ function createReport (lines) {
 }
 
 function createFunctionReport (name, lines, params) {
-  var result = {
+  const result = {
     cyclomatic: 1,
     halstead: createInitialHalsteadState(),
     name: name,
@@ -121,7 +122,7 @@ function processLloc (node, syntax, currentReport) {
 }
 
 function incrementCounter (node, syntax, name, incrementFn, currentReport) {
-  var amount = syntax[name]
+  const amount = syntax[name]
   if (_isNumber(amount)) {
     incrementFn(currentReport, amount)
   } else if (_isFunction(amount)) {
@@ -158,7 +159,7 @@ function processOperands (node, syntax, currentReport) {
 
 function processHalsteadMetric (node, syntax, metric, currentReport) {
   if (Array.isArray(syntax[metric])) {
-    syntax[metric].forEach(function (s) {
+    syntax[metric].forEach(s => {
       var identifier
       if (_isFunction(s.identifier)) {
         identifier = s.identifier(node)
@@ -245,7 +246,7 @@ function calculateMetrics (settings) {
     0,
     0
   ]
-  report.functions.forEach(function (functionReport) {
+  report.functions.forEach(functionReport => {
     calculateCyclomaticDensity(functionReport)
     calculateHalsteadMetrics(functionReport.halstead)
     sumMaintainabilityMetrics(sums, indices, functionReport)
@@ -257,11 +258,14 @@ function calculateMetrics (settings) {
     sumMaintainabilityMetrics(sums, indices, report.aggregate)
     count = 1
   }
-  averages = sums.map(function (sum) {
-    return sum / count
-  })
-  report.maintainability = calculateMaintainabilityIndex(averages[indices.effort], averages[indices.cyclomatic], averages[indices.loc], settings.newmi)
-  Object.keys(indices).forEach(function (index) {
+  averages = sums.map(sum => sum / count)
+  report.maintainability = calculateMaintainabilityIndex(
+    averages[indices.effort],
+    averages[indices.cyclomatic],
+    averages[indices.loc],
+    settings.newmi
+  )
+  Object.keys(indices).forEach(index => {
     report[index] = averages[indices[index]]
   })
 }

--- a/src/operands.js
+++ b/src/operands.js
@@ -1,11 +1,3 @@
-/* globals exports */
 'use strict'
-exports.actualise = actualiseOperands
 
-function actualiseOperands (identifiers) {
-  return identifiers.map(function (identifier) {
-    return {
-      identifier: identifier
-    }
-  })
-}
+module.exports.actualise = identifiers => identifiers.map(identifier => ({identifier}))

--- a/src/operators.js
+++ b/src/operators.js
@@ -1,14 +1,10 @@
-/* globals exports */
 'use strict'
-exports.actualise = actualiseOperators
 
-function actualiseOperators (properties) {
-  return properties.map(function (property) {
-    if (property && typeof property.identifier !== 'undefined') {
-      return property
-    }
-    return {
-      identifier: property
-    }
-  })
-}
+module.exports.actualise = properties => properties.map(property => {
+  if (property && typeof property.identifier !== 'undefined') {
+    return property
+  }
+  return {
+    identifier: property
+  }
+})

--- a/src/project.js
+++ b/src/project.js
@@ -1,20 +1,19 @@
 'use strict'
 
-var _isString = require('lodash.isstring')
-var assert = require('assert')
-var path = require('path')
-var moduleAnalyser = require('./module')
+const _isString = require('lodash.isstring')
+const assert = require('assert')
+const path = require('path')
+const moduleAnalyser = require('./module')
 
 exports.analyse = analyse
 exports.processResults = processResults
 
 function analyse (modules, walker, options) {
   // TODO: Asynchronize.
-  var reports
   options = options || {}
   assert(Array.isArray(modules), 'Invalid modules')
 
-  reports = modules.map(function (m) {
+  const reports = modules.map(m => {
     var report
     assert(_isString(m.path) && m.path.length > 0, 'Invalid path')
     try {
@@ -28,13 +27,9 @@ function analyse (modules, walker, options) {
     }
   }, [])
   if (options.skipCalculation) {
-    return {
-      reports: reports
-    }
+    return {reports}
   }
-  return processResults({
-    reports: reports
-  }, options.noCoreSize)
+  return processResults({reports}, options.noCoreSize)
 }
 
 function processResults (result, noCoreSize) {
@@ -48,26 +43,26 @@ function processResults (result, noCoreSize) {
 }
 
 function createAdjacencyMatrix (result) {
-  var adjacencyMatrix = new Array(result.reports.length)
-  var density = 0
-  result.reports.sort(function (lhs, rhs) {
-    return comparePaths(lhs.path, rhs.path)
-  }).forEach(function (ignore, x) {
-    adjacencyMatrix[x] = new Array(result.reports.length)
-    result.reports.forEach(function (ignore, y) {
-      adjacencyMatrix[x][y] = getAdjacencyMatrixValue(result.reports, x, y)
-      if (adjacencyMatrix[x][y] === 1) {
-        density += 1
-      }
+  const adjacencyMatrix = new Array(result.reports.length)
+  let density = 0
+  result.reports
+    .sort((lhs, rhs) => comparePaths(lhs.path, rhs.path))
+    .forEach((ignore, x) => {
+      adjacencyMatrix[x] = new Array(result.reports.length)
+      result.reports.forEach((ignore, y) => {
+        adjacencyMatrix[x][y] = getAdjacencyMatrixValue(result.reports, x, y)
+        if (adjacencyMatrix[x][y] === 1) {
+          density += 1
+        }
+      })
     })
-  })
   result.adjacencyMatrix = adjacencyMatrix
   result.firstOrderDensity = percentifyDensity(density, adjacencyMatrix)
 }
 
 function comparePaths (lhs, rhs) {
-  var lsplit = lhs.split(path.sep)
-  var rsplit = rhs.split(path.sep)
+  const lsplit = lhs.split(path.sep)
+  const rsplit = rhs.split(path.sep)
   if (lsplit.length < rsplit.length || (lsplit.length === rsplit.length && lhs < rhs)) {
     return -1
   }
@@ -88,7 +83,7 @@ function getAdjacencyMatrixValue (reports, x, y) {
 }
 
 function doesDependencyExist (from, to) {
-  return from.dependencies.reduce(function (result, dependency) {
+  return from.dependencies.reduce((result, dependency) => {
     if (result === false) {
       return checkDependency(from.path, dependency, to.path)
     }
@@ -106,21 +101,25 @@ function checkDependency (from, dependency, to) {
   return isDependency(from, dependency, to)
 }
 
-function isCommonJSDependency (dependency) {
-  return dependency.type === 'CommonJS'
-}
+const percentify = (value, limit) => limit === 0 ? 0 : (value / limit) * 100
+const percentifyDensity = (density, matrix) => percentify(density, matrix.length * matrix.length)
 
-function isInternalCommonJSDependency (dependency) {
-  return dependency.path[0] === '.' && (dependency.path[1] === path.sep || (dependency.path[1] === '.' && dependency.path[2] === path.sep))
-}
+const isCommonJSDependency = dependency => dependency.type === 'CommonJS'
+const isInternalCommonJSDependency = dependency => (
+  dependency.path[0] === '.' &&
+  (
+    dependency.path[1] === path.sep ||
+    (dependency.path[1] === '.' && dependency.path[2] === path.sep)
+  )
+)
 
 function isDependency (from, dependency, to) {
-  var dependencyPath = dependency.path
-  var fromFileAbsolutePath = path.resolve(from)
-  var toFileAbsolutePath = path.resolve(to)
-  var dependencyAbsolutePath = path.resolve(path.dirname(fromFileAbsolutePath), dependencyPath)
+  const dependencyPath = dependency.path
+  const fromFileAbsolutePath = path.resolve(from)
+  const toFileAbsolutePath = path.resolve(to)
+  let dependencyAbsolutePath = path.resolve(path.dirname(fromFileAbsolutePath), dependencyPath)
   if (path.extname(dependencyPath) === '') {
-    var index = path.join(dependencyAbsolutePath, 'index.js')
+    const index = path.join(dependencyAbsolutePath, 'index.js')
     if (index === toFileAbsolutePath) {
       return true
     } else {
@@ -130,63 +129,46 @@ function isDependency (from, dependency, to) {
   return dependencyAbsolutePath === toFileAbsolutePath
 }
 
-function percentifyDensity (density, matrix) {
-  return percentify(density, matrix.length * matrix.length)
-}
-
-function percentify (value, limit) {
-  if (limit === 0) {
-    return 0
-  }
-  return (value / limit) * 100
-}
-
 // Implementation of floydWarshall alg for calculating visibility matrix in O(n^3) instead of O(n^4) with successive raising of powers
 
 function createVisibilityMatrix (result) {
   var changeCost = 0
-  var visibilityMatrix
-  var matrixLen
-  var k
-  var i
-  var j
-  visibilityMatrix = adjacencyToDistMatrix(result.adjacencyMatrix)
-  matrixLen = visibilityMatrix.length
-  for (k = 0; k < matrixLen; k += 1) {
-    for (i = 0; i < matrixLen; i += 1) {
-      for (j = 0; j < matrixLen; j += 1) {
-        if (visibilityMatrix[i][j] > visibilityMatrix[i][k] + visibilityMatrix[k][j]) {
-          visibilityMatrix[i][j] = visibilityMatrix[i][k] + visibilityMatrix[k][j]
+  const distMatrix = adjacencyToDistMatrix(result.adjacencyMatrix)
+  const matrixLen = distMatrix.length
+  for (let k = 0; k < matrixLen; k += 1) {
+    for (let i = 0; i < matrixLen; i += 1) {
+      for (let j = 0; j < matrixLen; j += 1) {
+        if (distMatrix[i][j] > distMatrix[i][k] + distMatrix[k][j]) {
+          distMatrix[i][j] = distMatrix[i][k] + distMatrix[k][j]
         }
       }
     }
   }
 
   // Convert back from a distance matrix to adjacency matrix, while also calculating change cost
-  visibilityMatrix = visibilityMatrix.map(function (row, rowIndex) {
-    return row.map(function (value, columnIndex) {
-      if (value < Infinity) {
-        changeCost += 1
-        if (columnIndex !== rowIndex) {
-          return 1
+  const visibilityMatrix = distMatrix.map(
+    (row, rowIndex) => row.map(
+      (value, columnIndex) => {
+        if (value < Infinity) {
+          changeCost += 1
+          if (columnIndex !== rowIndex) {
+            return 1
+          }
         }
+        return 0
       }
-      return 0
-    })
-  })
+    )
+  )
   result.visibilityMatrix = visibilityMatrix
   result.changeCost = percentifyDensity(changeCost, visibilityMatrix)
 }
 
 function adjacencyToDistMatrix (matrix) {
-  var distMatrix = []
-  var i
-  var j
-  var value
-  for (i = 0; i < matrix.length; i += 1) {
+  const distMatrix = []
+  for (let i = 0; i < matrix.length; i += 1) {
     distMatrix.push([])
-    for (j = 0; j < matrix[i].length; j += 1) {
-      value = null
+    for (let j = 0; j < matrix[i].length; j += 1) {
+      let value = null
       if (i === j) {
         value = 1
       } else {
@@ -200,20 +182,16 @@ function adjacencyToDistMatrix (matrix) {
 }
 
 function setCoreSize (result) {
-  var fanIn
-  var fanOut
-  var boundaries
-  var coreSize
   if (result.firstOrderDensity === 0) {
     result.coreSize = 0
     return
   }
-  fanIn = new Array(result.visibilityMatrix.length)
-  fanOut = new Array(result.visibilityMatrix.length)
-  boundaries = {}
-  coreSize = 0
-  result.visibilityMatrix.forEach(function (row, rowIndex) {
-    fanIn[rowIndex] = row.reduce(function (sum, value, valueIndex) {
+  const fanIn = new Array(result.visibilityMatrix.length)
+  const fanOut = new Array(result.visibilityMatrix.length)
+  const boundaries = {}
+  let coreSize = 0
+  result.visibilityMatrix.forEach((row, rowIndex) => {
+    fanIn[rowIndex] = row.reduce((sum, value, valueIndex) => {
       if (rowIndex === 0) {
         fanOut[valueIndex] = value
       } else {
@@ -227,7 +205,7 @@ function setCoreSize (result) {
   // Distribution of values, but I've chosen the median to keep it simple.
   boundaries.fanIn = getMedian(fanIn.slice())
   boundaries.fanOut = getMedian(fanOut.slice())
-  result.visibilityMatrix.forEach(function (ignore, index) {
+  result.visibilityMatrix.forEach((ignore, index) => {
     if (fanIn[index] >= boundaries.fanIn && fanOut[index] >= boundaries.fanOut) {
       coreSize += 1
     }
@@ -254,9 +232,8 @@ function compareNumbers (lhs, rhs) {
 }
 
 function calculateAverages (result) {
-  var sums
   var divisor
-  sums = {
+  const sums = {
     cyclomatic: 0,
     effort: 0,
     loc: 0,
@@ -268,12 +245,10 @@ function calculateAverages (result) {
   } else {
     divisor = result.reports.length
   }
-  result.reports.forEach(function (report) {
-    Object.keys(sums).forEach(function (key) {
-      sums[key] += report[key]
-    })
-  })
-  Object.keys(sums).forEach(function (key) {
-    result[key] = sums[key] / divisor
-  })
+  result.reports.forEach(
+    report => Object.keys(sums).forEach(
+      key => { sums[key] += report[key] }
+    )
+  )
+  Object.keys(sums).forEach(key => { result[key] = sums[key] / divisor })
 }

--- a/src/safeName.js
+++ b/src/safeName.js
@@ -1,8 +1,9 @@
 'use strict'
-var _isObject = require('lodash.isobject')
-var _isString = require('lodash.isstring')
 
-module.exports = function (object, defaultName) {
+const _isObject = require('lodash.isobject')
+const _isString = require('lodash.isstring')
+
+module.exports = (object, defaultName) => {
   if (
     _isObject(object) &&
     _isString(object.name) &&

--- a/src/traits.js
+++ b/src/traits.js
@@ -1,23 +1,8 @@
-/* globals require, exports */
 'use strict'
-var operatorTraits = require('./operators')
-var operandTraits = require('./operands')
-exports.actualise = actualise
 
-function actualise (lloc, cyclomatic, operators, operands, children, assignableName, newScope, dependencies) {
-  return {
-    assignableName: assignableName,
-    children: safeArray(children),
-    cyclomatic: cyclomatic,
-    dependencies: dependencies,
-    lloc: lloc,
-    newScope: newScope,
-    operands: operandTraits.actualise(safeArray(operands)),
-    operators: operatorTraits.actualise(safeArray(operators))
-  }
-}
-
-function safeArray (thing) {
+const operatorTraits = require('./operators')
+const operandTraits = require('./operands')
+const safeArray = thing => {
   if (typeof thing === 'undefined') {
     return []
   }
@@ -28,3 +13,23 @@ function safeArray (thing) {
     thing
   ]
 }
+
+module.exports.actualise = (
+  lloc,
+  cyclomatic,
+  operators,
+  operands,
+  children,
+  assignableName,
+  newScope,
+  dependencies
+) => ({
+  assignableName,
+  children: safeArray(children),
+  cyclomatic,
+  dependencies,
+  lloc,
+  newScope,
+  operands: operandTraits.actualise(safeArray(operands)),
+  operators: operatorTraits.actualise(safeArray(operators))
+})

--- a/src/walker.js
+++ b/src/walker.js
@@ -1,11 +1,11 @@
 'use strict'
 
-var _isObject = require('lodash.isobject')
-var _isFunction = require('lodash.isfunction')
-var assert = require('assert')
-var safeName = require('./safeName')
-var syntaxDefinitions = require('./syntax')
-var debug = require('debug')('escomplex:walker')
+const _isObject = require('lodash.isobject')
+const _isFunction = require('lodash.isfunction')
+const assert = require('assert')
+const safeName = require('./safeName')
+const syntaxDefinitions = require('./syntax')
+const debug = require('debug')('escomplex:walker')
 
 module.exports.walk = walk
 
@@ -25,20 +25,17 @@ function walk (tree, settings, callbacks) {
   assert(_isFunction(callbacks.createScope), 'Invalid createScope callback')
   assert(_isFunction(callbacks.popScope), 'Invalid popScope callback')
 
-  var syntaxes = syntaxDefinitions.get(settings)
+  const syntaxes = syntaxDefinitions.get(settings)
   visitNodes(tree.body)
 
   function visitNodes (nodes, assignedName) {
-    nodes.forEach(function (node) {
-      visitNode(node, assignedName)
-    })
+    nodes.forEach(node => visitNode(node, assignedName))
   }
 
   function visitNode (node, assignedName) {
-    var syntax
     if (_isObject(node)) {
       debug('node type: ' + node.type)
-      syntax = syntaxes[node.type]
+      const syntax = syntaxes[node.type]
       debug('syntax: ' + JSON.stringify(syntax))
       if (_isObject(syntax)) {
         callbacks.processNode(node, syntax)
@@ -54,16 +51,17 @@ function walk (tree, settings, callbacks) {
   }
 
   function visitChildren (node) {
-    var syntax = syntaxes[node.type]
+    const syntax = syntaxes[node.type]
     if (Array.isArray(syntax.children)) {
-      syntax.children.forEach(function (child) {
-        visitChild(node[child], _isFunction(syntax.assignableName) ? syntax.assignableName(node) : '')
-      })
+      syntax.children.forEach(child => visitChild(
+        node[child],
+        _isFunction(syntax.assignableName) ? syntax.assignableName(node) : ''
+      ))
     }
   }
 
   function visitChild (child, assignedName) {
-    var visitor = Array.isArray(child) ? visitNodes : visitNode
+    const visitor = Array.isArray(child) ? visitNodes : visitNode
     visitor(child, assignedName)
   }
 }


### PR DESCRIPTION
Remove outdated node versions from travis configuration refactor
non-syntax modules to use const/let, short-hand properties, and arrow
functions where convenient.