### PR TITLE
Parse ES8 syntax

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   ],
   "dependencies": {
     "debug": "^2.6.2",
-    "espree": "^3.1.5",
+    "espree": "^3.4.3",
     "esprima": "^4.0.0",
     "lodash.assign": "^4.2.0",
     "lodash.isfunction": "^3.0.8",

--- a/src/config.js
+++ b/src/config.js
@@ -1,6 +1,6 @@
 'use strict'
 
 module.exports.parserOptions = {
-  ecmaVersion: 7,
+  ecmaVersion: 8,
   loc: true
 }

--- a/test/helpers/parsers.js
+++ b/test/helpers/parsers.js
@@ -17,6 +17,22 @@ var parsers = [
     parser: require('espree')
   },
   {
+    name: 'espree',
+    options: {
+      ecmaVersion: 7,
+      loc: true
+    },
+    parser: require('espree')
+  },
+  {
+    name: 'espree',
+    options: {
+      ecmaVersion: 8,
+      loc: true
+    },
+    parser: require('espree')
+  },
+  {
     name: 'esprima',
     options: {
       loc: true

--- a/test/index.js
+++ b/test/index.js
@@ -119,7 +119,7 @@ suite('index:', function () {
       test('espree.parse was given correct options first time', function () {
         assert.isObject(log.args['espree.parse'][0][1])
         assert.isTrue(log.args['espree.parse'][0][1].loc)
-        assert.equal(log.args['espree.parse'][0][1].ecmaVersion, 7)
+        assert.equal(log.args['espree.parse'][0][1].ecmaVersion, 8)
         assert.lengthOf(Object.keys(log.args['espree.parse'][0][1]), 2)
       })
       test('espree.parse was passed two arguments second time', function () {
@@ -131,7 +131,7 @@ suite('index:', function () {
       test('espree.parse was given correct options second time', function () {
         assert.isObject(log.args['espree.parse'][1][1])
         assert.isTrue(log.args['espree.parse'][1][1].loc)
-        assert.equal(log.args['espree.parse'][1][1].ecmaVersion, 7)
+        assert.equal(log.args['espree.parse'][1][1].ecmaVersion, 8)
         assert.lengthOf(Object.keys(log.args['espree.parse'][1][1]), 2)
       })
       test('core.analyse was called once', function () {
@@ -217,7 +217,7 @@ suite('index:', function () {
       test('espree.parse was given correct options', function () {
         assert.isObject(log.args['espree.parse'][0][1])
         assert.isTrue(log.args['espree.parse'][0][1].loc)
-        assert.equal(log.args['espree.parse'][0][1].ecmaVersion, 7)
+        assert.equal(log.args['espree.parse'][0][1].ecmaVersion, 8)
         assert.lengthOf(Object.keys(log.args['espree.parse'][0][1]), 2)
       })
       test('core.analyse was called once', function () {


### PR DESCRIPTION
Make default espree `ecmaVersion` 8 not 7.

This required upgrading espree to `3.4.3`.

I also added unit tests for `ecmaVersion` 7 and 8.